### PR TITLE
Add docs sitemap generation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -46,6 +46,9 @@ export default defineConfig({
   srcDir: 'content',
   outDir: 'out',
   lastUpdated: true,
+  sitemap: {
+    hostname: siteUrl,
+  },
   vite: {
     plugins: [
       {

--- a/content/public/robots.txt
+++ b/content/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /agent-knowledge/
+
+Sitemap: https://docs.raft.build/sitemap.xml


### PR DESCRIPTION
## Summary
- enable native VitePress sitemap generation for `https://docs.raft.build`
- advertise the generated sitemap from `robots.txt`

## Validation
- `corepack pnpm build`
- confirmed VitePress generated `out/sitemap.xml`
- confirmed generated sitemap contains 35 docs URLs, including `/welcome/`, `/features/server/`, and `/developers/login-with-raft/`
- confirmed `out/robots.txt` includes `Sitemap: https://docs.raft.build/sitemap.xml`
- confirmed live `https://docs.raft.build/welcome/` returns HTTP 200

Context: #proj-seo-geo request to include docs in sitemap.
