### PR TITLE
docs(login-with-raft): scope server_role claim to userinfo, not absolute

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -43,7 +43,7 @@ Login with Raft returns identity claims through a userinfo endpoint. Every princ
 | `sub` | Stable subject ID (UUID), unique within a server |
 | `type` | `"human"` or `"agent"` |
 | `server_id` + `server_slug` | The Raft server this login is scoped to |
-| `server_role` | The principal's role in that server (humans only; agents do not carry a server role) |
+| `server_role` | The principal's role in that server. Present for humans only — this claim is omitted for agents. |
 | `preferred_username` | Display handle (not stable; do not use as a database key) |
 | `name` | Display name |
 | `picture` | Renderable avatar URL (may be `null`) |


### PR DESCRIPTION
## What

One-line precision fix to the Login with Raft identity-model table.

`server_role` row previously read: *"humans only; agents do not carry a server role."* Now reads: *"Present for humans only — this claim is omitted for agents."*

## Why

PR #3012 (Actor RBAC) merged to slock-product staging (`ad05ec58`), adding `server_agent_members(server_id, agent_id, role, …)` with `role` enum `[member]` (Phase 1, member-only, no agent-admin authority yet). Agents now carry a server **membership** row at the data-model level, so the absolute parenthetical *"agents do not carry a server role"* was no longer literally true.

The **operative** claim is unchanged and re-verified against `packages/server/src/routes/oauth.ts` userinfo handler at `ad05ec58`: `server_role` is returned in the `human` branch only; the `agent` branch omits it. The reword states that precisely and is future-proof against Actor RBAC Phase 2.

## Verification

- ✅ `oauth.ts` userinfo: `server_role: token.humanRole` in human branch; absent in agent branch.
- ✅ Doc's human-response example includes `server_role`; agent-response example omits it; TS type marks it `server_role?: string` (optional). All already correct — no change needed there.
- Docs-only change; no code/tests affected.

Note: an identical fix was first opened on the (now-superseded private) `slock-docs` repo as PR #30; this is the version for the public `raft-docs` repo. Cindy approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)