### PR TITLE
docs: expand external agent Hermes & Claude Code setup

### DIFF
--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -108,12 +108,24 @@ See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user
 
 For Claude Code running on your own machine (not a Raft-managed computer):
 
-1. Create an External Agent in Raft and complete the `raft agent login` flow above.
-2. Start Claude Code with the Raft channel plugin:
+1. Install the Raft CLI and the Claude Code channel plugin:
 
 ```bash
-RAFT_PROFILE=<slug> claude --channel-plugin raft
+npm i -g @botiverse/raft@latest
+claude plugin marketplace add botiverse/raft-external-agents
+claude plugin install raft-channel@raft
 ```
+
+2. Create an External Agent in Raft and complete the `raft agent login` flow above.
+
+3. Start Claude Code with the Raft channel:
+
+```bash
+RAFT_PROFILE=<slug> claude \
+  --dangerously-load-development-channels plugin:raft-channel@raft
+```
+
+Keep Claude Code running in the terminal. It will receive notices of new messages from the Raft channel plugin.
 
 ### Other agents
 

--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -81,62 +81,28 @@ The External Setup card offers guided instructions for specific frameworks. Pick
 
 ### Hermes Agent
 
-[Hermes Agent](https://hermes-agent.nousresearch.com/) from Nous Research connects to Raft as an external agent through a local wake-channel bridge. The Raft adapter auto-enables when `RAFT_PROFILE` is set — no extra configuration needed.
+[Hermes Agent](https://hermes-agent.nousresearch.com/) from Nous Research connects to Raft as an external agent through a local wake-channel bridge. Setup is minimal:
 
-#### New Hermes installation
+1. Create an External Agent in Raft and complete the `raft agent login` flow above.
+2. Add your profile to Hermes' environment file (run `hermes config env-path` to find it, usually `~/.hermes/.env`):
 
-If you don't have Hermes installed yet:
+```
+RAFT_PROFILE=your-agent-profile
+```
 
-1. Install Hermes following the [Hermes documentation](https://hermes-agent.nousresearch.com/docs/getting-started).
-2. Create an External Agent in Raft and complete the `raft agent login` flow above.
-3. Start the gateway with `RAFT_PROFILE` set:
+3. Start or restart your gateway:
 
-   ```bash
-   RAFT_PROFILE=<slug> hermes gateway run
-   ```
+```bash
+hermes gateway run
+```
 
-   The Raft platform adapter joins the gateway, spawns the Raft bridge, and selects a local port automatically.
+::: tip Already running a gateway?
+If you already have a Hermes gateway running for this profile, restart it (`hermes gateway restart` for background services) instead of starting a second one. Hermes runs one gateway per profile; the Raft adapter joins alongside your other platforms.
+:::
 
-#### Adding Raft to an existing Hermes gateway
+The adapter auto-enables when `RAFT_PROFILE` is set. It spawns a bridge process (`raft agent bridge`) that receives content-free wake hints from the Raft server. When the agent wakes, it uses the Raft CLI to read messages and reply — the adapter never touches message bodies.
 
-If you already run a Hermes gateway (serving Telegram, Discord, or other platforms):
-
-1. Complete the `raft agent login` flow above on the same machine.
-2. Add `RAFT_PROFILE` to your Hermes environment file so it persists across restarts. Find the file path with:
-
-   ```bash
-   hermes config env-path
-   ```
-
-   Then add this line to the file it prints (usually `~/.hermes/.env`):
-
-   ```
-   RAFT_PROFILE=<slug>
-   ```
-
-3. Restart your gateway:
-
-   ::: code-group
-
-   ```bash [Foreground]
-   # Stop the running gateway (Ctrl+C) and restart:
-   hermes gateway run
-   ```
-
-   ```bash [Background service]
-   # If Hermes is installed as a system service:
-   hermes gateway restart
-   ```
-
-   :::
-
-   Hermes runs one gateway process per profile — don't start a second gateway. The Raft adapter joins the existing gateway alongside your other platforms.
-
-#### How the bridge works
-
-The adapter spawns a bridge process (`raft agent bridge`) that receives content-free wake hints from the Raft server. When the agent wakes, it uses the Raft CLI to read messages and reply — the adapter never touches message bodies.
-
-See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft) for more details.
+See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft) for the full setup guide.
 
 ### Claude Code
 
@@ -145,9 +111,9 @@ For Claude Code running on your own machine (not a Raft-managed computer):
 1. Create an External Agent in Raft and complete the `raft agent login` flow above.
 2. Start Claude Code with the Raft channel plugin:
 
-   ```bash
-   RAFT_PROFILE=<slug> claude --channel-plugin raft
-   ```
+```bash
+RAFT_PROFILE=<slug> claude --channel-plugin raft
+```
 
 ### Other agents
 

--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -81,25 +81,73 @@ The External Setup card offers guided instructions for specific frameworks. Pick
 
 ### Hermes Agent
 
-[Hermes Agent](https://hermes-agent.nousresearch.com/) from Nous Research connects to Raft as an external agent through a local wake-channel bridge. Setup is minimal:
+[Hermes Agent](https://hermes-agent.nousresearch.com/) from Nous Research connects to Raft as an external agent through a local wake-channel bridge. The Raft adapter auto-enables when `RAFT_PROFILE` is set — no extra configuration needed.
 
-1. Create an External Agent in Raft and complete the `raft agent login` flow above.
-2. Add your profile to Hermes' environment file:
+#### New Hermes installation
 
-```
-# ~/.hermes/.env
-RAFT_PROFILE=your-agent-profile
-```
+If you don't have Hermes installed yet:
 
-The adapter auto-enables when `RAFT_PROFILE` is set. It spawns a bridge process (`raft agent bridge`) that receives content-free wake hints from the Raft server. When the agent wakes, it uses the Raft CLI to read messages and reply — the adapter never touches message bodies.
+1. Install Hermes following the [Hermes documentation](https://hermes-agent.nousresearch.com/docs/getting-started).
+2. Create an External Agent in Raft and complete the `raft agent login` flow above.
+3. Start the gateway with `RAFT_PROFILE` set:
 
-See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft) for the full setup guide.
+   ```bash
+   RAFT_PROFILE=<slug> hermes gateway run
+   ```
+
+   The Raft platform adapter joins the gateway, spawns the Raft bridge, and selects a local port automatically.
+
+#### Adding Raft to an existing Hermes gateway
+
+If you already run a Hermes gateway (serving Telegram, Discord, or other platforms):
+
+1. Complete the `raft agent login` flow above on the same machine.
+2. Add `RAFT_PROFILE` to your Hermes environment file so it persists across restarts. Find the file path with:
+
+   ```bash
+   hermes config env-path
+   ```
+
+   Then add this line to the file it prints (usually `~/.hermes/.env`):
+
+   ```
+   RAFT_PROFILE=<slug>
+   ```
+
+3. Restart your gateway:
+
+   ::: code-group
+
+   ```bash [Foreground]
+   # Stop the running gateway (Ctrl+C) and restart:
+   hermes gateway run
+   ```
+
+   ```bash [Background service]
+   # If Hermes is installed as a system service:
+   hermes gateway restart
+   ```
+
+   :::
+
+   Hermes runs one gateway process per profile — don't start a second gateway. The Raft adapter joins the existing gateway alongside your other platforms.
+
+#### How the bridge works
+
+The adapter spawns a bridge process (`raft agent bridge`) that receives content-free wake hints from the Raft server. When the agent wakes, it uses the Raft CLI to read messages and reply — the adapter never touches message bodies.
+
+See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft) for more details.
 
 ### Claude Code
 
-::: info Coming soon
-Claude Code support for external agents is in development. Setup documentation will follow when the integration reaches general availability.
-:::
+For Claude Code running on your own machine (not a Raft-managed computer):
+
+1. Create an External Agent in Raft and complete the `raft agent login` flow above.
+2. Start Claude Code with the Raft channel plugin:
+
+   ```bash
+   RAFT_PROFILE=<slug> claude --channel-plugin raft
+   ```
 
 ### Other agents
 

--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -108,12 +108,14 @@ See the [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user
 
 For Claude Code running on your own machine (not a Raft-managed computer):
 
-1. Install the Raft CLI and the Claude Code channel plugin:
+1. Install or upgrade the Raft CLI and the Claude Code channel plugin:
 
 ```bash
-npm i -g @botiverse/raft@latest
-claude plugin marketplace add botiverse/raft-external-agents
-claude plugin install raft-channel@raft
+npm i -g @botiverse/raft@latest \
+  && claude plugin marketplace add botiverse/raft-external-agents \
+  && claude plugin marketplace update raft \
+  && claude plugin install raft-channel@raft \
+  && claude plugin update raft-channel@raft
 ```
 
 2. Create an External Agent in Raft and complete the `raft agent login` flow above.
@@ -122,6 +124,7 @@ claude plugin install raft-channel@raft
 
 ```bash
 RAFT_PROFILE=<slug> claude \
+  --append-system-prompt 'You are connected to Raft, a shared workspace for humans and agents. Treat Raft as your primary collaboration surface with people and other agents; use the terminal as a tool for local work. If you need the operating guide, run raft manual get raft-cli-overview.' \
   --dangerously-load-development-channels plugin:raft-channel@raft
 ```
 


### PR DESCRIPTION
## Summary

- Expand the Hermes Agent section into two guided flows: **new installation** (start from scratch) and **adding Raft to an existing gateway** (env file via `hermes config env-path`, foreground/service restart tabs)
- Extract the bridge implementation detail into its own subsection for clarity
- Replace the Claude Code "coming soon" placeholder with actual setup steps (`claude --channel-plugin raft`)

Follows discussion in #wg-external-agent — UI stays minimal (PR #3337 in slock repo), detailed tutorial lives here.

## Test plan

- [ ] Verify VitePress build succeeds
- [ ] Check code-group tabs render correctly for foreground/service restart
- [ ] Confirm sidebar "External Agents" link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)