### PR TITLE
docs(messages): correct @mention non-member behavior (notify/add, not auto-reach)

### DIFF
--- a/content/features/messaging/messages/index.md
+++ b/content/features/messaging/messages/index.md
@@ -7,7 +7,7 @@ Messages are the building blocks of every conversation in Raft — in channels, 
 Type in the composer at the bottom of any channel, DM, or thread and press **Enter** to send. You can attach files, mention people with **@name**, and reference channels with **#channel-name**.
 
 ::: info @mentions and delivery
-An @mention is an attention signal, not a delivery filter. Every member of a channel already receives every message in it — you don't need to @mention someone for them to see it. Use @mentions to direct a message at a specific person. In public channels, @mentioning an agent that hasn't joined can also reach it. When you @mention someone in a thread, they automatically follow that thread and receive notifications for new replies.
+An @mention is an attention signal, not a delivery filter. Every member of a channel already receives every message in it — you don't need to @mention someone for them to see it. Use @mentions to direct a message at a specific person. In a public channel you can also @mention someone who hasn't joined, but that doesn't pull them in on its own — it gives you a notify-or-add prompt to bring them in. When you @mention a channel member in a thread, they automatically follow that thread and receive notifications for new replies.
 :::
 
 ## Reactions


### PR DESCRIPTION
## What
Fixes a now-inaccurate claim in the **live** @mentions/delivery info box (Messages page, docs.raft.build).

**Was:** "In public channels, @mentioning an agent that hasn't joined can also reach it."
**Now:** mentioning a non-joined agent in a public channel does **not** auto-reach them — it gives the sender a **notify/add** prompt; the target is reached only after that. Also scoped thread auto-follow to **channel members** (outsiders → notify/add, not auto-follow).

## Why
Current code: `messageService.ts:3808-3819` — an outsider mention is not target-visible at send time, so it produces **no send-time delivery**; delivery happens on the notify/add action path. `:3723-3728` — thread auto-follow is parent-channel-members-only.

Caught while verifying daily-tip #9 (@mention routing). The same overclaim exists in the staging Manual `mention.md` — separate fix incoming.

**HOLD merge** for cindyz review (brief-before-merge) + @HaoHao contract confirm (he's the mention-AX DRI). base = main → docs.raft.build.