### PR TITLE
Add PostHog analytics to raft-docs (task #46)

### DIFF
--- a/.vitepress/theme/analytics.ts
+++ b/.vitepress/theme/analytics.ts
@@ -1,0 +1,154 @@
+// PostHog analytics for the Raft docs site.
+//
+// Scope + rationale (see #proj-landing task #46 / thread 38807de9):
+// - Client-side only, and only on the production host docs.raft.build. Preview
+//   builds and local dev stay inert (wrong host or no key => no-op), so nothing
+//   is tracked outside production.
+// - Env contract mirrors raft-landing PR #120 so the two sites share one schema
+//   and their events join cleanly: VITE_POSTHOG_PROJECT_API_KEY (fallback
+//   VITE_POSTHOG_KEY), VITE_POSTHOG_API_HOST (fallback VITE_POSTHOG_HOST),
+//   default host https://us.i.posthog.com. The public project key is injected
+//   at build time in Cloudflare Pages and never committed, so this file is inert
+//   until that env var is set.
+// - Measurement model: named KPI events are the reporting口径 (source of truth);
+//   autocapture is left ON only as a raw/exploration layer. Docs has fewer
+//   conversion surfaces than landing, so DOM-level noise is acceptable as long
+//   as the KPIs read from named events. Session replay (if wanted) is a separate
+//   PostHog project toggle, independent of this file.
+//
+// KPI events:
+// - docs_external_link_clicked: an outbound link click, tagged with
+//   destination_product_surface=app|signup|landing when recognizable. This is
+//   the "did docs drive people to the product" signal.
+// - docs_search: a search query (+ results_count when readable). Doubles as a
+//   docs/Manual gap signal — what people search for and whether docs answered it.
+
+const PROD_HOST = 'docs.raft.build'
+
+function readEnv(...names: string[]): string | undefined {
+  const env = (import.meta as { env?: Record<string, string | undefined> }).env
+  if (!env) return undefined
+  for (const name of names) {
+    const value = env[name]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}
+
+function classifyProductSurface(url: URL): string | undefined {
+  const host = url.hostname
+  if (host === 'app.raft.build') {
+    return /^\/sign[-_]?up/i.test(url.pathname) ? 'signup' : 'app'
+  }
+  if (host === 'raft.build' || host === 'www.raft.build') return 'landing'
+  return undefined
+}
+
+function anchorLocation(anchor: Element): string {
+  if (anchor.closest('.VPNavBar, .VPNav')) return 'nav'
+  if (anchor.closest('.VPSidebar')) return 'sidebar'
+  if (anchor.closest('.VPDocFooter')) return 'doc_footer'
+  if (anchor.closest('.VPFooter, footer')) return 'footer'
+  return 'content'
+}
+
+// VitePress local search renders an input inside the VPLocalSearchBox modal.
+// Selectors are defensive (class + aria-label fallback) and confirmed against
+// the live search DOM before relying on docs_search for reporting.
+function isSearchInput(input: HTMLInputElement): boolean {
+  if (input.closest('.VPLocalSearchBox')) return true
+  return (input.getAttribute('aria-label') || '').toLowerCase().includes('search')
+}
+
+function readSearchResultsCount(): number | undefined {
+  try {
+    const box = document.querySelector('.VPLocalSearchBox')
+    if (!box) return undefined
+    return box.querySelectorAll('ul li').length
+  } catch {
+    return undefined
+  }
+}
+
+let booted = false
+
+export async function initAnalytics(): Promise<void> {
+  // Browser + production host only. Everything else stays inert.
+  if (typeof window === 'undefined') return
+  if (window.location.hostname !== PROD_HOST) return
+  if (booted) return
+
+  const key = readEnv('VITE_POSTHOG_PROJECT_API_KEY', 'VITE_POSTHOG_KEY')
+  if (!key) return // no key configured in this build => stay inert
+  const apiHost = readEnv('VITE_POSTHOG_API_HOST', 'VITE_POSTHOG_HOST') ?? 'https://us.i.posthog.com'
+
+  booted = true
+
+  const { default: posthog } = await import('posthog-js')
+  posthog.init(key, {
+    api_host: apiHost,
+    autocapture: true, // raw/exploration layer only; KPIs are the named events below
+    capture_pageview: 'history_change',
+    capture_pageleave: true,
+    person_profiles: 'identified_only',
+  })
+
+  registerKpiListeners(posthog)
+}
+
+function registerKpiListeners(posthog: typeof import('posthog-js').default): void {
+  // Outbound link clicks (the product-egress KPI). Internal navigation is
+  // already covered by pageviews, so only cross-origin links are reported.
+  document.addEventListener(
+    'click',
+    (event) => {
+      try {
+        const target = event.target as Element | null
+        const anchor = target?.closest?.('a[href]') as HTMLAnchorElement | null
+        if (!anchor) return
+        let url: URL
+        try {
+          url = new URL(anchor.getAttribute('href') || '', window.location.href)
+        } catch {
+          return
+        }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return
+        if (url.origin === window.location.origin) return // internal nav => pageview covers it
+        posthog.capture('docs_external_link_clicked', {
+          page_path: window.location.pathname,
+          link_url: url.href,
+          link_text: (anchor.textContent || '').trim().slice(0, 120),
+          link_location: anchorLocation(anchor),
+          is_external: true,
+          destination_product_surface: classifyProductSurface(url),
+        })
+      } catch {
+        // Analytics must never break navigation.
+      }
+    },
+    { capture: true },
+  )
+
+  // Search queries (docs/Manual gap signal). Debounced so we log the settled
+  // query, not every keystroke.
+  let searchTimer: ReturnType<typeof setTimeout> | undefined
+  document.addEventListener('input', (event) => {
+    try {
+      const target = event.target as HTMLElement | null
+      if (!target || target.tagName !== 'INPUT') return
+      if (!isSearchInput(target as HTMLInputElement)) return
+      const query = (target as HTMLInputElement).value.trim()
+      if (searchTimer) clearTimeout(searchTimer)
+      if (!query) return
+      searchTimer = setTimeout(() => {
+        posthog.capture('docs_search', {
+          page_path: window.location.pathname,
+          query,
+          results_count: readSearchResultsCount(),
+        })
+      }, 600)
+    } catch {
+      // ignore
+    }
+  })
+}

--- a/.vitepress/theme/analytics.ts
+++ b/.vitepress/theme/analytics.ts
@@ -22,6 +22,12 @@
 //   the "did docs drive people to the product" signal.
 // - docs_search: a search query (+ results_count when readable). Doubles as a
 //   docs/Manual gap signal — what people search for and whether docs answered it.
+// - docs_code_copied: a code-block copy-button click (+ language). autocapture
+//   already records the raw click; this is the stable named口径 for it.
+//
+// Note: every button/link click and SPA navigation is also captured broadly by
+// autocapture + capture_pageview ("别漏" layer); the named events above are the
+// "好分析" KPI layer on top.
 
 const PROD_HOST = 'docs.raft.build'
 
@@ -124,6 +130,31 @@ function registerKpiListeners(posthog: typeof import('posthog-js').default): voi
         })
       } catch {
         // Analytics must never break navigation.
+      }
+    },
+    { capture: true },
+  )
+
+  // Code-block copy clicks. autocapture already records the raw button click;
+  // this is the stable named口径 (Cindy called the copy button out explicitly).
+  document.addEventListener(
+    'click',
+    (event) => {
+      try {
+        const target = event.target as Element | null
+        const button = target?.closest?.('button.copy') as HTMLButtonElement | null
+        if (!button) return
+        const block = button.closest('div[class*="language-"]')
+        const language =
+          Array.from(block?.classList || [])
+            .find((c) => c.startsWith('language-'))
+            ?.slice('language-'.length) || undefined
+        posthog.capture('docs_code_copied', {
+          page_path: window.location.pathname,
+          language,
+        })
+      } catch {
+        // never break the copy action
       }
     },
     { capture: true },

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import { useData } from 'vitepress'
 import { h } from 'vue'
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client'
 import './custom.css'
+import { initAnalytics } from './analytics'
 
 function markdownHref(relativePath: string) {
   if (relativePath === 'index.md') return '/index.md'
@@ -43,5 +44,8 @@ export default {
   },
   enhanceApp({ app }: EnhanceAppContext) {
     enhanceAppWithTabs(app)
+    // Fire-and-forget. initAnalytics is a no-op during SSR, off the production
+    // host, and when no PostHog key is configured — so it's safe to call here.
+    void initAnalytics()
   },
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "vitepress": "1.6.4",
     "vitepress-plugin-tabs": "^0.9.0",
     "vue": "^3.5.35"
+  },
+  "dependencies": {
+    "posthog-js": "^1.393.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      posthog-js:
+        specifier: ^1.393.5
+        version: 1.393.5
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -292,6 +296,12 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@posthog/core@1.37.3':
+    resolution: {integrity: sha512-Dvw4CTlRVH4K5ag/B8YIHgG4E27w43MCUsXpn1iKQHIggIMN3Shq9whG4Omm3OvXPF+VikBTmpyMKUjckPxw+g==}
+
+  '@posthog/types@1.391.1':
+    resolution: {integrity: sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==}
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
     cpu: [arm]
@@ -462,6 +472,9 @@ packages:
   '@types/node@22.19.18':
     resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -589,6 +602,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -598,6 +614,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -613,6 +632,9 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
@@ -689,11 +711,17 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.393.5:
+    resolution: {integrity: sha512-gYIULHldc2MDmeXE75ykRJYlZ7Q75jAYAzxr0vjD3wnfW1CZoQxV6YydaPRcDyWllJfO4UJPSQJfk9s1UIMa9A==}
+
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -827,6 +855,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1059,6 +1090,12 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@posthog/core@1.37.3':
+    dependencies:
+      '@posthog/types': 1.391.1
+
+  '@posthog/types@1.391.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
@@ -1196,6 +1233,9 @@ snapshots:
   '@types/node@22.19.18':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@3.0.3': {}
 
@@ -1338,6 +1378,8 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-js@3.49.0: {}
+
   csstype@3.2.3: {}
 
   dequal@2.0.3: {}
@@ -1345,6 +1387,10 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   emoji-regex-xs@1.0.0: {}
 
@@ -1377,6 +1423,8 @@ snapshots:
       '@esbuild/win32-x64': 0.21.5
 
   estree-walker@2.0.2: {}
+
+  fflate@0.4.8: {}
 
   focus-trap@7.8.0:
     dependencies:
@@ -1468,9 +1516,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.393.5:
+    dependencies:
+      '@posthog/core': 1.37.3
+      '@posthog/types': 1.391.1
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   preact@10.29.2: {}
 
   property-information@7.1.0: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -1656,5 +1717,7 @@ snapshots:
       '@vue/shared': 3.5.35
     optionalDependencies:
       typescript: 5.9.3
+
+  web-vitals@5.3.0: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Adds PostHog to the docs site, env-gated so it's **inert until the production key is set** (task #46, thread #proj-landing:38807de9).

## Behavior
- **Client-side + production-host only.** Initializes only when `window.location.hostname === "docs.raft.build"` **and** a key is present. Preview builds and local dev are no-ops — nothing tracked outside prod.
- **Env contract mirrors raft-landing PR #120** (so the two sites share one schema and join cleanly):
  - `VITE_POSTHOG_PROJECT_API_KEY` (fallback `VITE_POSTHOG_KEY`)
  - `VITE_POSTHOG_API_HOST` (fallback `VITE_POSTHOG_HOST`), default `https://us.i.posthog.com`
  - init: `capture_pageview: "history_change"`, `capture_pageleave: true`, `person_profiles: "identified_only"`
- The public project key is injected at **build time** in Cloudflare Pages (Vite `VITE_*`), **never committed**. Until huxijin provides it, this PR is fully inert.

## Measurement model
Named KPI events are the **reporting口径**; `autocapture` is left **on as a raw exploration layer only** (docs has fewer conversion surfaces than landing, so DOM noise is acceptable as long as KPIs read from named events). This is the one intentional divergence from landing's `autocapture:false` — easy to flip if you'd rather keep docs identical.

### KPI events
- `docs_external_link_clicked` — outbound clicks, tagged `destination_product_surface=app|signup|landing` + `link_location` (nav/sidebar/footer/content). The "did docs drive people to the product" signal.
- `docs_search` — search `query` + `results_count`. Doubles as a **docs/Manual gap signal** (what people search for and whether docs answered it).

## Validation
- `npx tsc --noEmit` ✅
- `pnpm build` ✅ — posthog-js code-splits into its own lazy chunk that only loads once the prod-host + key guards pass (verified in `out/`).

## Open / follow-up
- ⏳ **PostHog public project key** from @huxijin (春蕾 requested via DM) → set as Cloudflare Pages build env var to activate.
- The VitePress local-search selectors for `docs_search` are defensive (class + aria-label) and should be confirmed against the live search DOM once the key is in and events flow.

Handoff details from @春蕾: thread #proj-landing:38807de9. cc @cindyz

Signed-off-by: Maggie <maggie@mail.build>

🤖 Generated with [Claude Code](https://claude.com/claude-code)