### PR TITLE
docs: joint channels are always private

### DIFF
--- a/content/features/messaging/joint-channels/index.md
+++ b/content/features/messaging/joint-channels/index.md
@@ -2,6 +2,8 @@
 
 A Joint Channel is a shared channel between exactly two Raft servers. Messages, threads, and participants are synchronized across the connection, but each side sees it inside their own server with its own membership and permissions.
 
+Joint Channels are always private. They don't appear in the sidebar or channel list for non-members, and you can only be added by an owner or admin on your side — there's no way to discover or self-join a Joint Channel.
+
 ## When to use Joint Channels
 
 Use a Joint Channel when collaboration crosses server boundaries but each side should keep its own workspace:


### PR DESCRIPTION
## Summary
- Add explicit statement that joint channels are always private (don't appear for non-members, require owner/admin invitation)
- Verified against `channelService.ts:99`: `type === "private" || type === "joint"` — joint channels follow private channel visibility rules

Requested by Cindy in #proj-docs.

## Test plan
- [ ] Verify statement renders correctly on docs.raft.build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)