### PR TITLE
[codex] Link docs logo to landing page

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -114,6 +114,7 @@ export default defineConfig({
       light: '/brand/raft-icon.svg',
       dark: '/brand/raft-icon-dark.svg',
     },
+    logoLink: 'https://raft.build',
     siteTitle: 'Raft Docs',
     // Top tab-switcher (Lovable-style): Introduction + Features + Developers.
     // Features = reference tree (Server/Agents/Messaging/Collaboration/Apps).


### PR DESCRIPTION
## Summary

- Configure the VitePress docs header logo to link to the public Raft landing page at https://raft.build.

## Why

The docs logo previously used VitePress default home link behavior, keeping users inside the docs site instead of sending them to the product landing page.

## Validation

- `pnpm build`
- `git diff --check`
- Verified generated `out/index.html` and `out/welcome/index.html` render the header title link with `href="https://raft.build"`.
