### PR TITLE
docs: social links (Community / X / LinkedIn) in the footer

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -240,7 +240,14 @@ export default defineConfig({
       text: 'Edit this page on GitHub',
     },
     footer: {
-      message: 'built by humans and agents.',
+      // Social links live in the footer (not the nav) so the top bar stays
+      // focused on docs nav + the Open Raft CTA. Links match the Welcome page's
+      // "Talk to us" section.
+      message:
+        'built by humans and agents. &nbsp;·&nbsp; ' +
+        '<a href="https://app.raft.build/s/community" target="_blank" rel="noreferrer">Community</a> &nbsp;·&nbsp; ' +
+        '<a href="https://x.com/raft_hq" target="_blank" rel="noreferrer">X</a> &nbsp;·&nbsp; ' +
+        '<a href="https://www.linkedin.com/company/rafthq" target="_blank" rel="noreferrer">LinkedIn</a>',
       copyright: `© ${new Date().getFullYear()} Raft`,
     },
   },

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -448,3 +448,11 @@
 .vp-doc .plugin-tabs--content {
   border-radius: 0;
 }
+
+/* VitePress hides the global footer on pages that have a sidebar
+   (.VPFooter.has-sidebar { display: none }), which is every docs page here, so
+   the footer (tagline + social links + copyright) never showed. Force it on so
+   the social links are visible site-wide, below the prev/next doc footer. */
+.VPFooter.has-sidebar {
+  display: block;
+}


### PR DESCRIPTION
Per cindyz (the deferred "social media" footer follow-up). Surfaces social links in the docs **footer** (not the nav — the top bar stays focused on docs tabs + the Open Raft CTA, per the earlier nav-hierarchy pass).

Links match the Welcome page's "Talk to us" section (verified): Community (`app.raft.build/s/community`), X (`@raft_hq`), LinkedIn. Open in new tab.

Build green; links present in the built footer. cc @cindyz

(Note: header-logo→raft.build is @Dozy's task #49, separate; both are small config.mts edits at different lines.)

Signed-off-by: Maggie <maggie@mail.build>

🤖 Generated with [Claude Code](https://claude.com/claude-code)