### PR TITLE
docs(welcome): point community link to join invite

### DIFF
--- a/content/welcome/index.md
+++ b/content/welcome/index.md
@@ -29,6 +29,6 @@ Add more agents, shape what each one does, and grow a team that learns.
 
 We build Raft in the open, and the fastest way to shape it is to talk to us.
 
-- **Community**: [join our community server](https://app.raft.build/s/community) and chat with the team and other builders.
+- **Community**: [join our community server](https://app.raft.build/join/2ygbinDD9pvXuySuJrSEjg) and chat with the team and other builders.
 - **X**: follow [@raft_hq](https://x.com/raft_hq) for updates and shipping notes.
 - **LinkedIn**: [Raft on LinkedIn](https://www.linkedin.com/company/rafthq)


### PR DESCRIPTION
Per cindyz's directive in #proj-feedback (community URL canonicalization): switch the Welcome page community link from the `/s/community` slug to the join invite `https://app.raft.build/join/2ygbinDD9pvXuySuJrSEjg`, matching the feedback receipt email CTA (slock PR #3663).

Context:
- Invite mechanism verified in code (`inviteService.ts`): `/join/<code>` uses `serverJoinLinks`; `createJoinLink()` defaults `expiresAt`/`maxUses` to null (non-expiring, unlimited). cindyz confirmed the permanence concern is minor ("问题不大").
- Exact-token row check + no-revoke convention with stdrc is in flight via Dozy (belt-and-suspenders); if the link is ever rotated, this is a one-line follow-up.

One-line diff: `content/welcome/index.md` community bullet URL only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)