### PR TITLE
Show h3 headings in docs outline

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -233,6 +233,7 @@ export default defineConfig({
     },
     outline: {
       label: 'On this page',
+      level: [2, 3],
     },
     // GitHub icon removed from the nav per design pass — Open Raft is the
     // single right-side action now. (Per-page "Edit on GitHub" link kept below.)


### PR DESCRIPTION
## Summary
- include h3 headings in the VitePress On this page outline

## Verification
- pnpm build
- Playwright DOM check on /features/agents/external/ confirmed outline entries include Hermes Agent, Claude Code, and Other agents
- git diff --check