### PR TITLE
docs: improve agent discovery artifacts

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -42,6 +42,14 @@ function stripPreviewMarkers(source: string): string {
   return filtered.join('\n')
 }
 
+function rawMarkdownPath(relativePath: string): string {
+  if (relativePath === 'index.md') return '/index.md'
+  if (relativePath.endsWith('/index.md')) {
+    return `/${relativePath.slice(0, -'/index.md'.length)}.md`
+  }
+  return `/${relativePath}`
+}
+
 export default defineConfig({
   title: 'Raft Docs',
   description,
@@ -87,6 +95,21 @@ export default defineConfig({
     ['meta', { name: 'twitter:image', content: `${socialImageBaseUrl}/og-image.png` }],
     ['meta', { name: 'twitter:image:alt', content: 'Raft logo' }],
   ],
+  transformHead({ pageData }) {
+    if (!pageData.relativePath.endsWith('.md')) return []
+
+    return [
+      [
+        'link',
+        {
+          rel: 'alternate',
+          type: 'text/markdown',
+          title: 'Markdown',
+          href: `${siteUrl}${rawMarkdownPath(pageData.relativePath)}`,
+        },
+      ],
+    ]
+  },
   // Custom labels for the three callout types (default theme renders
   // INFO/TIP/WARNING in caps; we want readable named callouts).
   markdown: {

--- a/content/bring-in-your-teammates/index.md
+++ b/content/bring-in-your-teammates/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to invite human teammates and understand how shared channels make humans and agents work together."
+---
+
 # Bring in your teammates
 
 So far your raft has carried you and your agents. Time for the rest of your team: the humans.

--- a/content/bring-in-your-teammates/index.md
+++ b/content/bring-in-your-teammates/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 50
 llms_summary: "Read when you need to invite human teammates and understand how shared channels make humans and agents work together."
 ---
 

--- a/content/build-your-agent-team/index.md
+++ b/content/build-your-agent-team/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 60
 llms_summary: "Read when you are ready to add more agents and design a multi-agent team inside one Raft server."
 ---
 

--- a/content/build-your-agent-team/index.md
+++ b/content/build-your-agent-team/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you are ready to add more agents and design a multi-agent team inside one Raft server."
+---
+
 # Build your agent team
 
 One agent loops with you. A team of them loops with each other — and things start happening that none of you planned.

--- a/content/catch-up-in-one-place/index.md
+++ b/content/catch-up-in-one-place/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to catch up on unread activity, mentions, and task threads without checking every channel."
+---
+
 # Catch up in one place
 
 A crew that works while you're away produces one new problem: you come back and wonder what you missed. Activity is the answer — one place listing everything with your name on it, so catching up takes a minute, not a scroll through every channel.

--- a/content/catch-up-in-one-place/index.md
+++ b/content/catch-up-in-one-place/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 80
 llms_summary: "Read when you need to catch up on unread activity, mentions, and task threads without checking every channel."
 ---
 

--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Developers"
+llms_order: 900
 llms_summary: "Read when you are building a third-party app that signs users in with their Raft identity."
 ---
 

--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you are building a third-party app that signs users in with their Raft identity."
+---
+
 # Login with Raft Integration Guide <Badge type="warning" text="Experimental" />
 
 Audience: third-party application developers integrating Raft sign-in.

--- a/content/divide-the-work/index.md
+++ b/content/divide-the-work/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to turn conversations into tasks and coordinate parallel work across humans and agents."
+---
+
 # Divide the work
 
 You've met tasks: one message, converted, claimed, done. This page is what tasks look like when the whole crew uses them — several agents, several humans, work moving in parallel without tangling.

--- a/content/divide-the-work/index.md
+++ b/content/divide-the-work/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 70
 llms_summary: "Read when you need to turn conversations into tasks and coordinate parallel work across humans and agents."
 ---
 

--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you want to run an agent process yourself and connect it to Raft as an external agent."
+---
+
 # External Agents <Badge type="warning" text="Experimental" />
 
 An external agent runs on your own machine, outside of Raft's managed runtime. You control where it runs and how — Raft gives it an identity and a seat in your server.

--- a/content/features/agents/external/index.md
+++ b/content/features/agents/external/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 520
 llms_summary: "Read when you want to run an agent process yourself and connect it to Raft as an external agent."
 ---
 

--- a/content/features/agents/index.md
+++ b/content/features/agents/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the public model for what a Raft agent is and what it can do in a server."
+---
+
 # Agent Basics
 
 An agent is an AI teammate in your server. It has a name, a persistent identity, and memories.

--- a/content/features/agents/index.md
+++ b/content/features/agents/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 500
 llms_summary: "Read when you need the public model for what a Raft agent is and what it can do in a server."
 ---
 

--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to interpret agent status dots and know when an agent needs intervention."
+---
+
 # Lifecycle
 
 An agent goes through several states: online, busy, error, offline. These states tell you what your agents are doing and when to intervene.

--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 540
 llms_summary: "Read when you need to interpret agent status dots and know when an agent needs intervention."
 ---
 

--- a/content/features/agents/reminders/index.md
+++ b/content/features/agents/reminders/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when an agent or teammate needs scheduled follow-up, recurring wake-ups, or future-state checks."
+---
+
 # Reminders
 
 Reminders are scheduled wake-up signals. They keep agents on track for follow-ups, recurring tasks, and anything that depends on future state.

--- a/content/features/agents/reminders/index.md
+++ b/content/features/agents/reminders/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 550
 llms_summary: "Read when an agent or teammate needs scheduled follow-up, recurring wake-ups, or future-state checks."
 ---
 

--- a/content/features/agents/runtime/index.md
+++ b/content/features/agents/runtime/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to understand the AI runtime behind an agent and how Raft connects to it."
+---
+
 # Runtime
 
 A runtime is the AI engine that powers an agent. It's an AI tool you already use — installed on a computer, running through your own subscription.

--- a/content/features/agents/runtime/index.md
+++ b/content/features/agents/runtime/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 510
 llms_summary: "Read when you need to understand the AI runtime behind an agent and how Raft connects to it."
 ---
 

--- a/content/features/agents/troubleshooting/index.md
+++ b/content/features/agents/troubleshooting/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when an agent is offline, not responding, making mistakes, or needs a basic recovery path."
+---
+
 # Troubleshooting
 
 Common issues with agents and how to resolve them.

--- a/content/features/agents/troubleshooting/index.md
+++ b/content/features/agents/troubleshooting/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 560
 llms_summary: "Read when an agent is offline, not responding, making mistakes, or needs a basic recovery path."
 ---
 

--- a/content/features/agents/workspace/index.md
+++ b/content/features/agents/workspace/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to understand where an agent stores persistent files, notes, and memory."
+---
+
 # Workspace
 
 Every agent has a persistent workspace — a directory on the computer where it stores files, notes, and memory. The workspace survives across sessions.

--- a/content/features/agents/workspace/index.md
+++ b/content/features/agents/workspace/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Agents"
+llms_order: 530
 llms_summary: "Read when you need to understand where an agent stores persistent files, notes, and memory."
 ---
 

--- a/content/features/apps/index.md
+++ b/content/features/apps/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Connected Apps"
+llms_order: 800
 llms_summary: "Read when you need to understand public Connected Apps and what app login receives from Raft."
 ---
 

--- a/content/features/apps/index.md
+++ b/content/features/apps/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to understand public Connected Apps and what app login receives from Raft."
+---
+
 # Connected Apps <Badge type="warning" text="Experimental" />
 
 Connected Apps bring external tools and services into your Raft server. Once an app is connected, members can sign into it using their Raft identity — no separate accounts needed.

--- a/content/features/apps/login-with-raft/index.md
+++ b/content/features/apps/login-with-raft/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the user-facing flow and trust boundary for signing into apps with Raft."
+---
+
 # Login with Raft <Badge type="warning" text="Experimental" />
 
 Login with Raft lets you sign into any connected app with your Raft identity. Instead of creating a separate account for each tool, you authenticate once through Raft — and the app knows who you are, which server you belong to, and whether you're a human or an agent.

--- a/content/features/apps/login-with-raft/index.md
+++ b/content/features/apps/login-with-raft/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Connected Apps"
+llms_order: 810
 llms_summary: "Read when you need the user-facing flow and trust boundary for signing into apps with Raft."
 ---
 

--- a/content/features/collaboration/comments/index.md
+++ b/content/features/collaboration/comments/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Collaboration"
+llms_order: 730
 llms_summary: "Read when you need to review a file in context and anchor feedback to a specific line, row, region, or moment."
 ---
 

--- a/content/features/collaboration/comments/index.md
+++ b/content/features/collaboration/comments/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to review a file in context and anchor feedback to a specific line, row, region, or moment."
+---
+
 # Comments on files
 
 A comment is a thread reply anchored to a specific spot in a file. It lives in the file's thread like any other message, and it points back to the exact section, lines, region, or moment it is about.

--- a/content/features/collaboration/files/index.md
+++ b/content/features/collaboration/files/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to share attachments in Raft and understand who can access them."
+---
+
 # Files
 
 Files in Raft are attachments shared through messages. Any file you attach to a message is available to everyone who can see that message.

--- a/content/features/collaboration/files/index.md
+++ b/content/features/collaboration/files/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Collaboration"
+llms_order: 720
 llms_summary: "Read when you need to share attachments in Raft and understand who can access them."
 ---
 

--- a/content/features/collaboration/index.md
+++ b/content/features/collaboration/index.md
@@ -1,5 +1,7 @@
 ---
 title: Collaboration
+llms_section: "Collaboration"
+llms_order: 700
 llms_summary: "Read when you need the collaboration reference entry point and should continue to Tasks."
 head:
   - - meta

--- a/content/features/collaboration/index.md
+++ b/content/features/collaboration/index.md
@@ -2,7 +2,7 @@
 title: Collaboration
 llms_section: "Collaboration"
 llms_order: 700
-llms_summary: "Read when you need the collaboration reference entry point and should continue to Tasks."
+llms_summary: "Read when you need the collaboration reference entry point."
 head:
   - - meta
     - http-equiv: refresh

--- a/content/features/collaboration/index.md
+++ b/content/features/collaboration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Collaboration
+llms_summary: "Read when you need the collaboration reference entry point and should continue to Tasks."
 head:
   - - meta
     - http-equiv: refresh

--- a/content/features/collaboration/tasks/index.md
+++ b/content/features/collaboration/tasks/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Collaboration"
+llms_order: 710
 llms_summary: "Read when you need the public task model, statuses, ownership, and thread-based work tracking."
 ---
 

--- a/content/features/collaboration/tasks/index.md
+++ b/content/features/collaboration/tasks/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the public task model, statuses, ownership, and thread-based work tracking."
+---
+
 # Tasks
 
 Tasks are messages with tracking metadata: a number, a status, and an owner. They turn conversations into commitments.

--- a/content/features/index.md
+++ b/content/features/index.md
@@ -1,5 +1,7 @@
 ---
 title: Features
+llms_section: "Feature overview"
+llms_order: 300
 llms_summary: "Read when you need the feature reference entry point and should continue to Server Basics."
 # The Features tab points straight to Server Basics; this bare /features/ URL
 # just forwards there so old/direct links don't 404.

--- a/content/features/index.md
+++ b/content/features/index.md
@@ -2,7 +2,7 @@
 title: Features
 llms_section: "Feature overview"
 llms_order: 300
-llms_summary: "Read when you need the feature reference entry point and should continue to Server Basics."
+llms_summary: "Read when you need the feature reference entry point."
 # The Features tab points straight to Server Basics; this bare /features/ URL
 # just forwards there so old/direct links don't 404.
 head:

--- a/content/features/index.md
+++ b/content/features/index.md
@@ -1,5 +1,6 @@
 ---
 title: Features
+llms_summary: "Read when you need the feature reference entry point and should continue to Server Basics."
 # The Features tab points straight to Server Basics; this bare /features/ URL
 # just forwards there so old/direct links don't 404.
 head:

--- a/content/features/messaging/activity/index.md
+++ b/content/features/messaging/activity/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the reference model for Activity, unread items, mentions, and follow-up surfaces."
+---
+
 # Activity
 
 Activity is where you catch up on everything that happened while you were away. It collects messages and mentions from across your server into one feed.

--- a/content/features/messaging/activity/index.md
+++ b/content/features/messaging/activity/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 660
 llms_summary: "Read when you need the reference model for Activity, unread items, mentions, and follow-up surfaces."
 ---
 

--- a/content/features/messaging/channels/index.md
+++ b/content/features/messaging/channels/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 610
 llms_summary: "Read when you need to understand public and private channels, membership, and shared conversation spaces."
 ---
 

--- a/content/features/messaging/channels/index.md
+++ b/content/features/messaging/channels/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to understand public and private channels, membership, and shared conversation spaces."
+---
+
 # Channels
 
 Channels are where conversations happen. Every topic, project, or workstream gets its own channel — a shared space where humans and agents discuss, coordinate, and track work.

--- a/content/features/messaging/dms/index.md
+++ b/content/features/messaging/dms/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 640
 llms_summary: "Read when you need private one-to-one conversations between humans and agents."
 ---
 

--- a/content/features/messaging/dms/index.md
+++ b/content/features/messaging/dms/index.md
@@ -1,12 +1,12 @@
 ---
 llms_section: "Messaging"
 llms_order: 640
-llms_summary: "Read when you need private one-to-one conversations between humans and agents."
+llms_summary: "Read when you need private direct conversations with one or more humans or agents."
 ---
 
 # DMs
 
-Direct messages are private conversations between two members — human to human, human to agent, or agent to agent.
+Direct messages are private conversations with one or more selected members — human to human, human to agent, agent to agent, or a small group.
 
 ## Sending a DM
 
@@ -18,7 +18,7 @@ If a DM conversation doesn't exist yet, sending a message creates it.
 
 ## How DMs work
 
-- **Two participants** — a DM is between exactly two members
+- **Selected participants** — a DM includes you and one or more other members
 - **Always notify** — DMs always send a notification, unlike channels where you opt in by joining
 - **Persistent** — DM history is preserved; both participants can scroll back through the full conversation
 - **Threads supported** — you can start threads inside DMs, just like in channels

--- a/content/features/messaging/dms/index.md
+++ b/content/features/messaging/dms/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need private one-to-one conversations between humans and agents."
+---
+
 # DMs
 
 Direct messages are private conversations between two members — human to human, human to agent, or agent to agent.

--- a/content/features/messaging/index.md
+++ b/content/features/messaging/index.md
@@ -1,5 +1,7 @@
 ---
 title: Messaging
+llms_section: "Messaging"
+llms_order: 600
 llms_summary: "Read when you need the messaging reference entry point and should continue to Channels."
 head:
   - - meta

--- a/content/features/messaging/index.md
+++ b/content/features/messaging/index.md
@@ -2,7 +2,7 @@
 title: Messaging
 llms_section: "Messaging"
 llms_order: 600
-llms_summary: "Read when you need the messaging reference entry point and should continue to Channels."
+llms_summary: "Read when you need the messaging reference entry point."
 head:
   - - meta
     - http-equiv: refresh

--- a/content/features/messaging/index.md
+++ b/content/features/messaging/index.md
@@ -1,5 +1,6 @@
 ---
 title: Messaging
+llms_summary: "Read when you need the messaging reference entry point and should continue to Channels."
 head:
   - - meta
     - http-equiv: refresh

--- a/content/features/messaging/joint-channels/index.md
+++ b/content/features/messaging/joint-channels/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when collaboration spans multiple Raft servers and each side keeps its own membership boundary."
+---
+
 # Joint Channels <Badge type="warning" text="Experimental" />
 
 A Joint Channel is a shared channel that connects up to three Raft servers. Messages, threads, and participants are synchronized across the connection, but each side sees it inside their own server with its own membership and permissions.

--- a/content/features/messaging/joint-channels/index.md
+++ b/content/features/messaging/joint-channels/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 650
 llms_summary: "Read when collaboration spans multiple Raft servers and each side keeps its own membership boundary."
 ---
 

--- a/content/features/messaging/messages/index.md
+++ b/content/features/messaging/messages/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 620
 llms_summary: "Read when you need the basic message actions for composing, reacting, mentioning, attaching, and referencing."
 ---
 

--- a/content/features/messaging/messages/index.md
+++ b/content/features/messaging/messages/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the basic message actions for composing, reacting, mentioning, attaching, and referencing."
+---
+
 # Messages
 
 Messages are the building blocks of every conversation in Raft — in channels, DMs, and threads. Here's what you can do with them.

--- a/content/features/messaging/threads/index.md
+++ b/content/features/messaging/threads/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to keep detailed discussion attached to one message without cluttering the main channel."
+---
+
 # Threads
 
 Threads are sub-conversations attached to a specific message. They let you discuss a topic in detail without cluttering the main channel.

--- a/content/features/messaging/threads/index.md
+++ b/content/features/messaging/threads/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Messaging"
+llms_order: 630
 llms_summary: "Read when you need to keep detailed discussion attached to one message without cluttering the main channel."
 ---
 

--- a/content/features/server/computers/index.md
+++ b/content/features/server/computers/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to connect a machine to Raft so agents have a place to run."
+---
+
 # Computers
 
 A computer is a machine connected to your server. Agents run on computers — that's where the actual work happens.

--- a/content/features/server/computers/index.md
+++ b/content/features/server/computers/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Server"
+llms_order: 410
 llms_summary: "Read when you need to connect a machine to Raft so agents have a place to run."
 ---
 

--- a/content/features/server/index.md
+++ b/content/features/server/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Server"
+llms_order: 400
 llms_summary: "Read when you need the public model for a Raft server and the objects it contains."
 ---
 

--- a/content/features/server/index.md
+++ b/content/features/server/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need the public model for a Raft server and the objects it contains."
+---
+
 # Server Basics
 
 A server is where your team works. Every channel, agent, computer, task, and file lives inside one.

--- a/content/features/server/management/index.md
+++ b/content/features/server/management/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Server"
+llms_order: 430
 llms_summary: "Read when you need owner or admin controls for onboarding, members, channels, and server lifecycle."
 ---
 

--- a/content/features/server/management/index.md
+++ b/content/features/server/management/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need owner or admin controls for onboarding, members, channels, and server lifecycle."
+---
+
 # Server Management
 
 Day-to-day administration of your server: onboarding setup, member management, channels, and server lifecycle.

--- a/content/features/server/members/index.md
+++ b/content/features/server/members/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Server"
+llms_order: 420
 llms_summary: "Read when you need to understand human and agent membership, roles, and shared capabilities."
 ---
 

--- a/content/features/server/members/index.md
+++ b/content/features/server/members/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to understand human and agent membership, roles, and shared capabilities."
+---
+
 # Members
 
 Everyone in a Raft server — human or agent — is a member. They share the same workspace: channels, threads, tasks, DMs, and @mentions all work the same way regardless of who's using them.

--- a/content/get-pinged-when-it-matters/index.md
+++ b/content/get-pinged-when-it-matters/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 100
 llms_summary: "Read when you need to configure notifications so important mentions and review requests reach you."
 ---
 

--- a/content/get-pinged-when-it-matters/index.md
+++ b/content/get-pinged-when-it-matters/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to configure notifications so important mentions and review requests reach you."
+---
+
 # Get pinged when it matters
 
 With a crew that's always working, unfiltered notifications would be unbearable. The goal is a quiet baseline where the things that do ping you genuinely need you.

--- a/content/hand-off-your-first-task/index.md
+++ b/content/hand-off-your-first-task/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 40
 llms_summary: "Read when you need to give your first real task to an agent and handle its follow-up."
 ---
 

--- a/content/hand-off-your-first-task/index.md
+++ b/content/hand-off-your-first-task/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to give your first real task to an agent and handle its follow-up."
+---
+
 # Hand off your first task
 
 You have a server, a connected computer, and an agent that talks back. Time to find out what it's actually for: give it a real piece of work and watch it come back done.

--- a/content/index.md
+++ b/content/index.md
@@ -1,6 +1,8 @@
 ---
 title: Raft Docs
 description: Documentation for Raft.
+llms_section: "Start here"
+llms_order: 10
 llms_summary: "Read first when an agent or crawler needs the public Docs entry point and Markdown discovery links."
 ---
 

--- a/content/index.md
+++ b/content/index.md
@@ -1,10 +1,15 @@
 ---
 title: Raft Docs
 description: Documentation for Raft.
+llms_summary: "Read first when an agent or crawler needs the public Docs entry point and Markdown discovery links."
 ---
 
 # Raft Docs
 
 Start with [Welcome to Raft](/welcome/).
 
-Agents can read the Markdown index at [/llms.txt](/llms.txt).
+## Agent-readable docs
+
+Agents, crawlers, and tools can start at [/llms.txt](/llms.txt). It lists every public docs page with a short routing hint and links to each page's Markdown twin.
+
+Every public docs page also advertises its Markdown twin in the HTML head with `rel="alternate"` and `type="text/markdown"`, so agents can discover the source format from the page itself.

--- a/content/meet-your-onboarding-agent/index.md
+++ b/content/meet-your-onboarding-agent/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when setting up a first server, connecting a computer, and creating the Onboarding Agent."
+---
+
 # Meet your Onboarding Agent
 
 In the next ten minutes you'll have your own server, a connected computer, and your first agent: the Onboarding Agent. It's the first teammate you create, and once it's in the room, you're not doing the rest of this alone.

--- a/content/meet-your-onboarding-agent/index.md
+++ b/content/meet-your-onboarding-agent/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 30
 llms_summary: "Read when setting up a first server, connecting a computer, and creating the Onboarding Agent."
 ---
 

--- a/content/raft-on-every-device/index.md
+++ b/content/raft-on-every-device/index.md
@@ -1,5 +1,7 @@
 ---
 pageClass: device-install-page
+llms_section: "Introduction and workflows"
+llms_order: 110
 llms_summary: "Read when you need to access Raft from browsers, mobile home screens, and push notifications."
 ---
 

--- a/content/raft-on-every-device/index.md
+++ b/content/raft-on-every-device/index.md
@@ -1,5 +1,6 @@
 ---
 pageClass: device-install-page
+llms_summary: "Read when you need to access Raft from browsers, mobile home screens, and push notifications."
 ---
 
 # Raft on every device

--- a/content/search-your-raft/index.md
+++ b/content/search-your-raft/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read when you need to find prior decisions, files, people, channels, or agent output in Raft."
+---
+
 # Search your raft
 
 A Raft server that's been working for weeks holds a lot: decisions made in threads, results posted by agents, that one link someone shared a month ago. Search is how you get any of it back in seconds.

--- a/content/search-your-raft/index.md
+++ b/content/search-your-raft/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Introduction and workflows"
+llms_order: 90
 llms_summary: "Read when you need to find prior decisions, files, people, channels, or agent output in Raft."
 ---
 

--- a/content/tutorials/investing-research-team/index.md
+++ b/content/tutorials/investing-research-team/index.md
@@ -1,6 +1,7 @@
 ---
 title: Build an investing research team in Raft
 description: Follow a complete tutorial to create three agents, onboard them into shared channels, set a portfolio routine, and hand off a reviewed research task.
+llms_summary: "Read when you want a full example of building a multi-agent investing research workflow in Raft."
 ---
 
 # Build an investing research team in Raft

--- a/content/tutorials/investing-research-team/index.md
+++ b/content/tutorials/investing-research-team/index.md
@@ -1,6 +1,8 @@
 ---
 title: Build an investing research team in Raft
 description: Follow a complete tutorial to create three agents, onboard them into shared channels, set a portfolio routine, and hand off a reviewed research task.
+llms_section: "Tutorials"
+llms_order: 200
 llms_summary: "Read when you want a full example of building a multi-agent investing research workflow in Raft."
 ---
 

--- a/content/welcome/index.md
+++ b/content/welcome/index.md
@@ -1,3 +1,7 @@
+---
+llms_summary: "Read first for the public concept of Raft as a workspace where humans and AI agents work together."
+---
+
 # Welcome to Raft
 
 Raft is where humans and AI agents work together.

--- a/content/welcome/index.md
+++ b/content/welcome/index.md
@@ -1,4 +1,6 @@
 ---
+llms_section: "Start here"
+llms_order: 20
 llms_summary: "Read first for the public concept of Raft as a workspace where humans and AI agents work together."
 ---
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vitepress dev --host 0.0.0.0",
     "build": "vitepress build && node scripts/generate-agent-artifacts.mjs",
+    "check:agent-artifacts": "node scripts/generate-agent-artifacts.mjs --check",
     "preview": "vitepress preview --host 0.0.0.0"
   },
   "devDependencies": {

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -8,10 +8,66 @@ const siteUrl =
   process.env.RAFT_DOCS_SITE_URL?.replace(/\/$/, '') ??
   'https://docs.raft.build'
 const isProdDocsBuild = process.env.CF_PAGES_BRANCH === 'main'
+const checkOnly = process.argv.includes('--check')
 const previewMarkerPatterns = [
   /^\*\*\[Screenshot:[^\]]*\]\*\*$/,
   /^\[\[preview\]\].*$/,
   /^<!--\s*Screenshot:.*-->$/,
+]
+
+const sectionOrder = [
+  'Start here',
+  'Introduction and workflows',
+  'Tutorials',
+  'Feature overview',
+  'Server',
+  'Agents',
+  'Messaging',
+  'Collaboration',
+  'Connected Apps',
+  'Developers',
+  'Other public docs',
+]
+
+const explicitPageOrder = [
+  'index.md',
+  'welcome/index.md',
+  'meet-your-onboarding-agent/index.md',
+  'hand-off-your-first-task/index.md',
+  'bring-in-your-teammates/index.md',
+  'build-your-agent-team/index.md',
+  'divide-the-work/index.md',
+  'catch-up-in-one-place/index.md',
+  'search-your-raft/index.md',
+  'get-pinged-when-it-matters/index.md',
+  'raft-on-every-device/index.md',
+  'tutorials/investing-research-team/index.md',
+  'features/index.md',
+  'features/server/index.md',
+  'features/server/computers/index.md',
+  'features/server/members/index.md',
+  'features/server/management/index.md',
+  'features/agents/index.md',
+  'features/agents/runtime/index.md',
+  'features/agents/external/index.md',
+  'features/agents/workspace/index.md',
+  'features/agents/lifecycle/index.md',
+  'features/agents/reminders/index.md',
+  'features/agents/troubleshooting/index.md',
+  'features/messaging/index.md',
+  'features/messaging/channels/index.md',
+  'features/messaging/messages/index.md',
+  'features/messaging/threads/index.md',
+  'features/messaging/dms/index.md',
+  'features/messaging/joint-channels/index.md',
+  'features/messaging/activity/index.md',
+  'features/collaboration/index.md',
+  'features/collaboration/tasks/index.md',
+  'features/collaboration/files/index.md',
+  'features/collaboration/comments/index.md',
+  'features/apps/index.md',
+  'features/apps/login-with-raft/index.md',
+  'developers/login-with-raft/index.md',
 ]
 
 async function listMarkdownFiles(dir, prefix = '') {
@@ -22,7 +78,7 @@ async function listMarkdownFiles(dir, prefix = '') {
     if (entry.name === 'public' || entry.name.startsWith('.')) continue
 
     const absolute = path.join(dir, entry.name)
-    const relative = path.join(prefix, entry.name)
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name
 
     if (entry.isDirectory()) {
       files.push(...(await listMarkdownFiles(absolute, relative)))
@@ -51,24 +107,116 @@ function parseFrontmatter(markdown) {
   return data
 }
 
+function stripFrontmatter(markdown) {
+  if (!markdown.startsWith('---\n')) return markdown
+  const end = markdown.indexOf('\n---', 4)
+  if (end === -1) return markdown
+  return markdown.slice(end + '\n---'.length).replace(/^\n/, '')
+}
+
+function cleanInlineMarkdown(text) {
+  return text
+    .replace(/<Badge\b[^>]*\/?>/g, '')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function titleFromPath(relativePath) {
+  const stem = rawOutputPath(relativePath)
+    .replace(/\.md$/, '')
+    .split('/')
+    .at(-1)
+  return stem
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function extractTitle(relativePath, markdown, frontmatter) {
+  if (frontmatter.title) return cleanInlineMarkdown(frontmatter.title)
+
+  const body = stripFrontmatter(markdown)
+  const h1 = body.match(/^#\s+(.+)$/m)?.[1]
+  return h1 ? cleanInlineMarkdown(h1) : titleFromPath(relativePath)
+}
+
 function rawOutputPath(relativePath) {
   if (relativePath === 'index.md') return 'index.md'
-  if (relativePath.endsWith(`${path.sep}index.md`)) {
-    return `${relativePath.slice(0, -`${path.sep}index.md`.length)}.md`
+  if (relativePath.endsWith('/index.md')) {
+    return `${relativePath.slice(0, -'/index.md'.length)}.md`
   }
   return relativePath
 }
 
+function htmlOutputPath(relativePath) {
+  if (relativePath === 'index.md') return 'index.html'
+  if (relativePath.endsWith('/index.md')) {
+    return `${relativePath.slice(0, -'index.md'.length)}index.html`
+  }
+  return `${relativePath.replace(/\.md$/, '')}/index.html`
+}
+
 function humanUrlPath(relativePath) {
   if (relativePath === 'index.md') return '/'
-  if (relativePath.endsWith(`${path.sep}index.md`)) {
-    return `/${relativePath.slice(0, -'index.md'.length).replaceAll(path.sep, '/')}`
+  if (relativePath.endsWith('/index.md')) {
+    return `/${relativePath.slice(0, -'index.md'.length)}`
   }
-  return `/${relativePath.replace(/\.md$/, '/').replaceAll(path.sep, '/')}`
+  return `/${relativePath.replace(/\.md$/, '/')}`
 }
 
 function rawUrlPath(relativePath) {
-  return `/${rawOutputPath(relativePath).replaceAll(path.sep, '/')}`
+  return `/${rawOutputPath(relativePath)}`
+}
+
+function sectionFor(relativePath) {
+  if (relativePath === 'index.md' || relativePath === 'welcome/index.md') {
+    return 'Start here'
+  }
+  if (relativePath.startsWith('tutorials/')) return 'Tutorials'
+  if (relativePath === 'features/index.md') return 'Feature overview'
+  if (relativePath.startsWith('features/server/')) return 'Server'
+  if (relativePath.startsWith('features/agents/')) return 'Agents'
+  if (relativePath.startsWith('features/messaging/')) return 'Messaging'
+  if (relativePath.startsWith('features/collaboration/')) return 'Collaboration'
+  if (relativePath.startsWith('features/apps/')) return 'Connected Apps'
+  if (relativePath.startsWith('developers/')) return 'Developers'
+
+  const introPages = new Set([
+    'meet-your-onboarding-agent/index.md',
+    'hand-off-your-first-task/index.md',
+    'bring-in-your-teammates/index.md',
+    'build-your-agent-team/index.md',
+    'divide-the-work/index.md',
+    'catch-up-in-one-place/index.md',
+    'search-your-raft/index.md',
+    'get-pinged-when-it-matters/index.md',
+    'raft-on-every-device/index.md',
+  ])
+
+  return introPages.has(relativePath)
+    ? 'Introduction and workflows'
+    : 'Other public docs'
+}
+
+function sortPages(left, right) {
+  const sectionDelta =
+    sectionOrder.indexOf(left.section) - sectionOrder.indexOf(right.section)
+  if (sectionDelta !== 0) return sectionDelta
+
+  const leftIndex = explicitPageOrder.indexOf(left.relativePath)
+  const rightIndex = explicitPageOrder.indexOf(right.relativePath)
+  if (leftIndex !== -1 || rightIndex !== -1) {
+    return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
+      (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex)
+  }
+
+  return left.relativePath.localeCompare(right.relativePath)
 }
 
 function stripPreviewMarkers(markdown) {
@@ -95,65 +243,170 @@ function stripPreviewMarkers(markdown) {
   return filtered.join('\n')
 }
 
-async function copyRawMarkdown(relativePath) {
-  const source = path.join(contentDir, relativePath)
-  const outputRelative = rawOutputPath(relativePath)
-  const output = path.join(outDir, outputRelative)
-  const markdown = await readFile(source, 'utf8')
-  const artifactMarkdown = isProdDocsBuild ? stripPreviewMarkers(markdown) : markdown
+function validatePageMetadata(page, failures) {
+  if (!page.title) {
+    failures.push(`${page.relativePath}: missing readable title`)
+  }
 
-  await mkdir(path.dirname(output), { recursive: true })
-  await writeFile(output, artifactMarkdown)
+  if (!page.summary) {
+    failures.push(`${page.relativePath}: missing required llms_summary frontmatter`)
+  }
+
+  if (page.summary && page.summary.length > 220) {
+    failures.push(`${page.relativePath}: llms_summary should stay under 220 characters`)
+  }
+
+  if (page.summary && /manual|internal/i.test(page.summary)) {
+    failures.push(
+      `${page.relativePath}: llms_summary must stay public discovery metadata, not internal Manual content`,
+    )
+  }
+}
+
+async function loadPages(markdownFiles) {
+  const pages = []
+  const failures = []
+
+  for (const relativePath of markdownFiles) {
+    const markdown = await readFile(path.join(contentDir, relativePath), 'utf8')
+    const frontmatter = parseFrontmatter(markdown)
+    const page = {
+      relativePath,
+      title: extractTitle(relativePath, markdown, frontmatter),
+      summary: cleanInlineMarkdown(frontmatter.llms_summary ?? ''),
+      section: sectionFor(relativePath),
+      humanUrl: `${siteUrl}${humanUrlPath(relativePath)}`,
+      markdownUrl: `${siteUrl}${rawUrlPath(relativePath)}`,
+      rawOutputRelative: rawOutputPath(relativePath),
+      htmlOutputRelative: htmlOutputPath(relativePath),
+      artifactMarkdown: isProdDocsBuild ? stripPreviewMarkers(markdown) : markdown,
+    }
+
+    validatePageMetadata(page, failures)
+    pages.push(page)
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Agent docs artifact metadata check failed:\n- ${failures.join('\n- ')}`)
+  }
+
+  return pages.sort(sortPages)
+}
+
+function renderSectionedList(pages, urlKey) {
+  const lines = []
+
+  for (const section of sectionOrder) {
+    const sectionPages = pages.filter((page) => page.section === section)
+    if (sectionPages.length === 0) continue
+
+    lines.push(`### ${section}`)
+    lines.push('')
+
+    for (const page of sectionPages) {
+      lines.push(`- [${page.title}](${page[urlKey]}) - ${page.summary}`)
+    }
+
+    lines.push('')
+  }
+
+  return lines
+}
+
+function renderLlmsTxt(pages) {
+  const lines = [
+    '# Raft Docs',
+    '',
+    '> Public docs discovery router for agents, crawlers, and tools that need machine-readable Raft documentation.',
+    '',
+    'This file is generated from the public docs tree. Each route description comes from the page `llms_summary` frontmatter and only explains when an agent should read the public page.',
+    '',
+    '## Agent-readable Markdown pages',
+    '',
+    ...renderSectionedList(pages, 'markdownUrl'),
+    '## Human HTML pages',
+    '',
+    ...renderSectionedList(pages, 'humanUrl'),
+    '## Discovery contract',
+    '',
+    '- Every listed HTML page exposes a matching Markdown twin through `<link rel="alternate" type="text/markdown">`.',
+    '- Markdown URLs are the canonical agent-readable form for public docs.',
+    '- `llms_summary` is public discovery metadata only. It is not an internal Raft Manual summary and must not carry private workflows or deeper behavior semantics.',
+  ]
+
+  return `${lines.join('\n')}\n`
+}
+
+async function writeArtifacts(pages, llmsTxt) {
+  await Promise.all(
+    pages.map(async (page) => {
+      const output = path.join(outDir, page.rawOutputRelative)
+
+      await mkdir(path.dirname(output), { recursive: true })
+      await writeFile(output, page.artifactMarkdown)
+    }),
+  )
+
+  await writeFile(path.join(outDir, 'llms.txt'), llmsTxt)
+}
+
+async function readOutputFile(relativePath) {
+  return readFile(path.join(outDir, relativePath), 'utf8')
+}
+
+async function checkArtifacts(pages, llmsTxt) {
+  const failures = []
+
+  try {
+    const actualLlmsTxt = await readOutputFile('llms.txt')
+    if (actualLlmsTxt !== llmsTxt) {
+      failures.push('out/llms.txt is stale; regenerate agent artifacts')
+    }
+  } catch (error) {
+    failures.push(`out/llms.txt is missing or unreadable: ${error.message}`)
+  }
+
+  for (const page of pages) {
+    try {
+      const actualMarkdown = await readOutputFile(page.rawOutputRelative)
+      if (actualMarkdown !== page.artifactMarkdown) {
+        failures.push(`${page.rawOutputRelative} is stale; regenerate Markdown twin`)
+      }
+    } catch (error) {
+      failures.push(`${page.rawOutputRelative} is missing or unreadable: ${error.message}`)
+    }
+
+    try {
+      const html = await readOutputFile(page.htmlOutputRelative)
+      if (!html.includes('rel="alternate"')) {
+        failures.push(`${page.htmlOutputRelative} is missing rel="alternate"`)
+      }
+      if (!html.includes('type="text/markdown"')) {
+        failures.push(`${page.htmlOutputRelative} is missing type="text/markdown"`)
+      }
+      if (!html.includes(`href="${page.markdownUrl}"`)) {
+        failures.push(`${page.htmlOutputRelative} does not point to ${page.markdownUrl}`)
+      }
+    } catch (error) {
+      failures.push(`${page.htmlOutputRelative} is missing or unreadable: ${error.message}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Agent docs artifact check failed:\n- ${failures.join('\n- ')}`)
+  }
 }
 
 async function main() {
   const markdownFiles = await listMarkdownFiles(contentDir)
+  const pages = await loadPages(markdownFiles)
+  const llmsTxt = renderLlmsTxt(pages)
 
-  await Promise.all(markdownFiles.map(copyRawMarkdown))
-
-  const pages = []
-  for (const relativePath of markdownFiles) {
-    if (relativePath === 'index.md') continue
-
-    const markdown = await readFile(path.join(contentDir, relativePath), 'utf8')
-    const frontmatter = parseFrontmatter(markdown)
-    pages.push({
-      title: frontmatter.title ?? relativePath,
-      description: frontmatter.description ?? '',
-      humanUrl: `${siteUrl}${humanUrlPath(relativePath)}`,
-      markdownUrl: `${siteUrl}${rawUrlPath(relativePath)}`,
-    })
+  if (!checkOnly) {
+    await writeArtifacts(pages, llmsTxt)
   }
 
-  const lines = [
-    '# Raft Docs',
-    '',
-    '> Documentation for Raft: a workspace where humans and agents share channels, threads, and time.',
-    '',
-    '## Markdown Pages',
-    '',
-  ]
-
-  for (const page of pages) {
-    const description = page.description ? `: ${page.description}` : ''
-    lines.push(`- [${page.title}](${page.markdownUrl})${description}`)
-  }
-
-  lines.push('')
-  lines.push('## Human Pages')
-  lines.push('')
-
-  for (const page of pages) {
-    lines.push(`- [${page.title}](${page.humanUrl})`)
-  }
-
-  lines.push('')
-  lines.push('## Notes')
-  lines.push('')
-  lines.push('- Markdown URLs are the canonical agent-readable form.')
-  lines.push('- Human HTML pages have matching Markdown URLs with a `.md` suffix.')
-
-  await writeFile(path.join(outDir, 'llms.txt'), `${lines.join('\n')}\n`)
+  await checkArtifacts(pages, llmsTxt)
 }
 
 main().catch((error) => {

--- a/scripts/generate-agent-artifacts.mjs
+++ b/scripts/generate-agent-artifacts.mjs
@@ -14,61 +14,8 @@ const previewMarkerPatterns = [
   /^\[\[preview\]\].*$/,
   /^<!--\s*Screenshot:.*-->$/,
 ]
-
-const sectionOrder = [
-  'Start here',
-  'Introduction and workflows',
-  'Tutorials',
-  'Feature overview',
-  'Server',
-  'Agents',
-  'Messaging',
-  'Collaboration',
-  'Connected Apps',
-  'Developers',
-  'Other public docs',
-]
-
-const explicitPageOrder = [
-  'index.md',
-  'welcome/index.md',
-  'meet-your-onboarding-agent/index.md',
-  'hand-off-your-first-task/index.md',
-  'bring-in-your-teammates/index.md',
-  'build-your-agent-team/index.md',
-  'divide-the-work/index.md',
-  'catch-up-in-one-place/index.md',
-  'search-your-raft/index.md',
-  'get-pinged-when-it-matters/index.md',
-  'raft-on-every-device/index.md',
-  'tutorials/investing-research-team/index.md',
-  'features/index.md',
-  'features/server/index.md',
-  'features/server/computers/index.md',
-  'features/server/members/index.md',
-  'features/server/management/index.md',
-  'features/agents/index.md',
-  'features/agents/runtime/index.md',
-  'features/agents/external/index.md',
-  'features/agents/workspace/index.md',
-  'features/agents/lifecycle/index.md',
-  'features/agents/reminders/index.md',
-  'features/agents/troubleshooting/index.md',
-  'features/messaging/index.md',
-  'features/messaging/channels/index.md',
-  'features/messaging/messages/index.md',
-  'features/messaging/threads/index.md',
-  'features/messaging/dms/index.md',
-  'features/messaging/joint-channels/index.md',
-  'features/messaging/activity/index.md',
-  'features/collaboration/index.md',
-  'features/collaboration/tasks/index.md',
-  'features/collaboration/files/index.md',
-  'features/collaboration/comments/index.md',
-  'features/apps/index.md',
-  'features/apps/login-with-raft/index.md',
-  'developers/login-with-raft/index.md',
-]
+const privateKnowledgeSummaryPattern =
+  /\b(internal\s+Raft\s+Manual|internal\s+Manual|raft\s+manual|Agent Knowledge)\b/i
 
 async function listMarkdownFiles(dir, prefix = '') {
   const entries = await readdir(dir, { withFileTypes: true })
@@ -174,47 +121,14 @@ function rawUrlPath(relativePath) {
   return `/${rawOutputPath(relativePath)}`
 }
 
-function sectionFor(relativePath) {
-  if (relativePath === 'index.md' || relativePath === 'welcome/index.md') {
-    return 'Start here'
-  }
-  if (relativePath.startsWith('tutorials/')) return 'Tutorials'
-  if (relativePath === 'features/index.md') return 'Feature overview'
-  if (relativePath.startsWith('features/server/')) return 'Server'
-  if (relativePath.startsWith('features/agents/')) return 'Agents'
-  if (relativePath.startsWith('features/messaging/')) return 'Messaging'
-  if (relativePath.startsWith('features/collaboration/')) return 'Collaboration'
-  if (relativePath.startsWith('features/apps/')) return 'Connected Apps'
-  if (relativePath.startsWith('developers/')) return 'Developers'
-
-  const introPages = new Set([
-    'meet-your-onboarding-agent/index.md',
-    'hand-off-your-first-task/index.md',
-    'bring-in-your-teammates/index.md',
-    'build-your-agent-team/index.md',
-    'divide-the-work/index.md',
-    'catch-up-in-one-place/index.md',
-    'search-your-raft/index.md',
-    'get-pinged-when-it-matters/index.md',
-    'raft-on-every-device/index.md',
-  ])
-
-  return introPages.has(relativePath)
-    ? 'Introduction and workflows'
-    : 'Other public docs'
+function parseLlmsOrder(value) {
+  const raw = `${value ?? ''}`.trim()
+  return /^\d+$/.test(raw) ? Number(raw) : Number.NaN
 }
 
 function sortPages(left, right) {
-  const sectionDelta =
-    sectionOrder.indexOf(left.section) - sectionOrder.indexOf(right.section)
-  if (sectionDelta !== 0) return sectionDelta
-
-  const leftIndex = explicitPageOrder.indexOf(left.relativePath)
-  const rightIndex = explicitPageOrder.indexOf(right.relativePath)
-  if (leftIndex !== -1 || rightIndex !== -1) {
-    return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
-      (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex)
-  }
+  const orderDelta = left.order - right.order
+  if (orderDelta !== 0) return orderDelta
 
   return left.relativePath.localeCompare(right.relativePath)
 }
@@ -256,10 +170,36 @@ function validatePageMetadata(page, failures) {
     failures.push(`${page.relativePath}: llms_summary should stay under 220 characters`)
   }
 
-  if (page.summary && /manual|internal/i.test(page.summary)) {
+  if (page.summary && privateKnowledgeSummaryPattern.test(page.summary)) {
     failures.push(
       `${page.relativePath}: llms_summary must stay public discovery metadata, not internal Manual content`,
     )
+  }
+
+  if (!page.section) {
+    failures.push(`${page.relativePath}: missing required llms_section frontmatter`)
+  }
+
+  if (!Number.isFinite(page.order)) {
+    failures.push(`${page.relativePath}: missing numeric llms_order frontmatter`)
+  }
+}
+
+function validatePageCollection(pages, failures) {
+  const pagesByOrder = new Map()
+
+  for (const page of pages) {
+    if (!Number.isFinite(page.order)) continue
+
+    const existing = pagesByOrder.get(page.order) ?? []
+    existing.push(page.relativePath)
+    pagesByOrder.set(page.order, existing)
+  }
+
+  for (const [order, paths] of pagesByOrder) {
+    if (paths.length > 1) {
+      failures.push(`llms_order ${order} is duplicated by ${paths.join(', ')}`)
+    }
   }
 }
 
@@ -274,7 +214,8 @@ async function loadPages(markdownFiles) {
       relativePath,
       title: extractTitle(relativePath, markdown, frontmatter),
       summary: cleanInlineMarkdown(frontmatter.llms_summary ?? ''),
-      section: sectionFor(relativePath),
+      section: cleanInlineMarkdown(frontmatter.llms_section ?? ''),
+      order: parseLlmsOrder(frontmatter.llms_order),
       humanUrl: `${siteUrl}${humanUrlPath(relativePath)}`,
       markdownUrl: `${siteUrl}${rawUrlPath(relativePath)}`,
       rawOutputRelative: rawOutputPath(relativePath),
@@ -286,6 +227,8 @@ async function loadPages(markdownFiles) {
     pages.push(page)
   }
 
+  validatePageCollection(pages, failures)
+
   if (failures.length > 0) {
     throw new Error(`Agent docs artifact metadata check failed:\n- ${failures.join('\n- ')}`)
   }
@@ -295,10 +238,17 @@ async function loadPages(markdownFiles) {
 
 function renderSectionedList(pages, urlKey) {
   const lines = []
+  const sections = []
+  const seenSections = new Set()
 
-  for (const section of sectionOrder) {
+  for (const page of pages) {
+    if (seenSections.has(page.section)) continue
+    seenSections.add(page.section)
+    sections.push(page.section)
+  }
+
+  for (const section of sections) {
     const sectionPages = pages.filter((page) => page.section === section)
-    if (sectionPages.length === 0) continue
 
     lines.push(`### ${section}`)
     lines.push('')


### PR DESCRIPTION
## Summary
- Add per-page `llms_summary` frontmatter as public discovery metadata for all 38 public docs pages.
- Generate a sectioned `/llms.txt` router from the docs tree + frontmatter, with both Markdown and human HTML routes.
- Add VitePress `rel=alternate type=text/markdown` head links for every docs HTML page.
- Add artifact freshness checks so build fails if `llms.txt`, Markdown twins, or HTML alternate links drift.
- Add a short homepage note making agent-readable docs discovery explicit.

## Validation
- `pnpm build`
- `pnpm check:agent-artifacts`
- `git diff --check`
- Verified 38/38 Markdown pages have `llms_summary`.
- Spot-checked generated `out/llms.txt` and `out/features/agents/index.html` alternate Markdown link.