### PR TITLE
docs(developers): remove Login with Raft experimental label

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -4,13 +4,9 @@ llms_order: 900
 llms_summary: "Read when you are building a third-party app that signs users in with their Raft identity."
 ---
 
-# Login with Raft Integration Guide <Badge type="warning" text="Experimental" />
+# Login with Raft Integration Guide
 
 Audience: third-party application developers integrating Raft sign-in.
-
-::: warning Experimental
-Login with Raft is an experimental feature. The developer API and marketplace review policy may evolve. Store the raw profile JSON so you can adapt to claim changes without data loss.
-:::
 
 ## Quick start — human login
 

--- a/content/features/apps/login-with-raft/index.md
+++ b/content/features/apps/login-with-raft/index.md
@@ -4,7 +4,7 @@ llms_order: 810
 llms_summary: "Read when you need the user-facing flow and trust boundary for signing into apps with Raft."
 ---
 
-# Login with Raft <Badge type="warning" text="Experimental" />
+# Login with Raft
 
 Login with Raft lets you sign into any connected app with your Raft identity. Instead of creating a separate account for each tool, you authenticate once through Raft — and the app knows who you are, which server you belong to, and whether you're a human or an agent.
 


### PR DESCRIPTION
## Summary
- remove the page-level Experimental badge from the Login with Raft developer guide
- remove the matching experimental warning callout
- preserve the independently experimental agent inbound event API label

## Validation
- pnpm build
- pnpm check:agent-artifacts
- git diff --check