### PR TITLE
docs(apps): align installed app Agent Login access

### DIFF
--- a/content/features/apps/index.md
+++ b/content/features/apps/index.md
@@ -72,12 +72,11 @@ The app is now available in your server. Your third-party tool uses these creden
 
 ## Agent access
 
-Agents can use connected apps just like humans — but with different trust boundaries depending on the app type:
+Agents can use connected apps just like humans. When an app is available to the server — because it is built in, server-local, or an installed marketplace app — Raft grants the agent access when it signs in. There is no separate per-agent approval card.
 
-- **Built-in and server-local apps** — agents are auto-granted access. No approval step needed.
-- **Third-party marketplace apps** — a server owner or admin must approve each agent's access before the agent can use the app.
+Marketplace installation is the human authorization boundary: a server owner or admin must install the app before any member or agent on that server can use it. A marketplace app that has not been installed fails closed.
 
-This means outside apps can't be used by agents without a human saying yes. The grant is specific: per-agent, per-app, per-server. Approving one agent for one app doesn't grant any other agent or any other app.
+Each agent grant is still specific to one agent, app, and server. It does not give another agent access, extend to another app, or apply to another server.
 
 ::: info Agents authenticate as themselves
 When an agent uses a connected app, it signs in with its own Raft identity — not a human's. Each agent's app access is isolated: one agent can't use another's credentials or sessions.

--- a/content/features/apps/login-with-raft/index.md
+++ b/content/features/apps/login-with-raft/index.md
@@ -23,26 +23,18 @@ The experience is similar to "Sign in with Google" — one click, no new passwor
 
 Agents can also sign into connected apps — as themselves, with their own Raft identity. This means an agent can use an external tool without borrowing a human's credentials.
 
-The flow depends on the app type:
+The flow depends on whether the app is available to the server:
 
-### Auto-granted apps (built-in + server-local)
+### Available apps
 
-For built-in and server-local apps, agents are granted access automatically. The agent signs in and starts using the app — no human approval step.
+Built-in apps, server-local apps, and marketplace apps installed on the server are available to its agents. Raft grants the agent access when it signs in, with no separate per-agent approval card.
 
-### Approved apps (third-party)
+### Marketplace apps that are not installed
 
-For third-party marketplace apps, the first time an agent needs access:
+An uninstalled marketplace app is not available to that server, so Agent Login fails closed. A server owner or admin must first install the app from **Settings → Connected Apps → Marketplace**. The agent can then retry and sign in without a separate approval step.
 
-1. The agent requests access to the app
-2. Raft creates a pending approval request
-3. An approval card is posted in the relevant channel or thread
-4. A server owner or admin approves the request
-5. The agent can now sign in to the app
-
-Once approved, the grant is remembered — the agent doesn't need re-approval for the same app unless the grant is revoked.
-
-::: info Approval is per-agent, per-app, per-server
-Approving Agent A for App X on your server doesn't grant Agent B, doesn't extend to other apps, and doesn't apply to other servers. Each grant is specific and revocable.
+::: info Access is per-agent, per-app, per-server
+Raft creates an isolated grant for each agent, app, and server. One agent's access does not grant another agent access, extend to another app, or apply to another server. Uninstalling the app or revoking the grant removes access.
 :::
 
 ## What gets shared
@@ -62,4 +54,4 @@ The app does **not** get access to your messages, channels, files, or other Raft
 - **Apps can't impersonate you** — a successful login creates a session for that specific app, not a general-purpose credential
 - **Human and agent logins are separate** — an agent can't reuse a human's browser session, and a human can't inherit an agent's app grant
 - **Grants are revocable** — server admins can uninstall an app (which revokes all grants for that server) or revoke individual agent access
-- **Third-party agent access is human-gated** — agents can't start using outside apps without a server owner or admin approving first
+- **Marketplace installation is human-gated** — a server owner or admin must install an outside app before agents on that server can use it


### PR DESCRIPTION
## Summary

- remove stale user-facing claims that each third-party Agent Login requires an owner/admin approval card
- document the shipped boundary: owner/admin installation makes a marketplace app available; available built-in, server-local, and installed marketplace apps auto-grant the signing-in agent
- preserve per-agent/per-app/per-server grant isolation, revocation, and fail-closed behavior for uninstalled marketplace apps

## Behavior source

- shipped Raft #4715 installed-app agent auto-grant contract
- raft-docs #35 already updated the developer guide to this production behavior; this PR closes the remaining contradiction in the two user-facing Connected Apps pages

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm check:agent-artifacts`
- `git diff --check`
- stale-copy scan across `content/`

No product code or deployment changes.
