### PR TITLE
fix(docs): redirect section roots at the edge

### DIFF
--- a/content/public/_redirects
+++ b/content/public/_redirects
@@ -10,6 +10,10 @@
 /reminders/  /welcome/  301
 /faq  /welcome/  301
 /faq/  /welcome/  301
+/developers  /developers/login-with-raft/  301
+/developers/  /developers/login-with-raft/  301
+/features  /features/server/  301
+/features/  /features/server/  301
 /agent-knowledge  /welcome/  302
 /agent-knowledge/  /welcome/  302
 /agent-knowledge/*  /welcome/  302


### PR DESCRIPTION
## Summary
- redirect `/developers` and `/developers/` directly to `/developers/login-with-raft/`
- redirect `/features` and `/features/` directly to `/features/server/`
- handle all four routes in the Cloudflare Pages `_redirects` contract, before any page HTML renders

## Requirement challenge
The intended behavior is an HTTP redirect at the hosting edge, not a VitePress page that briefly renders and then navigates. The smallest production change is four explicit rules because Cloudflare Pages treats trailing-slash and non-trailing-slash paths separately. The existing Features index remains as a fallback for non-Cloudflare/static hosting, but production routing intercepts both variants first.

## Verification
- `pnpm build`
- `pnpm exec tsc --noEmit`
- `git diff --check`
- confirmed `content/public/_redirects` is copied byte-for-byte to `out/_redirects`
- Cloudflare Wrangler Pages local runtime:
  - `/developers` -> `301 /developers/login-with-raft/`
  - `/developers/` -> `301 /developers/login-with-raft/`
  - `/features` -> `301 /features/server/`
  - `/features/` -> `301 /features/server/`
  - both destination pages return `200`
- reverse mutation: removing the `/features/` rule made that route return `200` (the intermediate page); restoring it returned the required `301`

Raft task: #proj-docs task #77
