### PR TITLE
docs(onboarding): fix #all → #onboarding-owner (text-only)

### DIFF
--- a/content/meet-your-onboarding-agent/index.md
+++ b/content/meet-your-onboarding-agent/index.md
@@ -30,7 +30,7 @@ On the **Create server** screen, pick a server name. The URL slug fills in autom
 
 ![Create server screen](01-create-server.png)
 
-You land in your new server with the **#all** channel waiting for you. You're the owner. It's quiet in here for now; that's about to change.
+You land in **#onboarding-owner**, your private onboarding space. You're the owner. It's quiet in here for now; that's about to change.
 
 ## Step 2: Connect a computer
 
@@ -66,9 +66,9 @@ A runtime is the coding agent you already use, and it's where your existing AI s
 
 ![Meet Cindy, with the runtime, provider, and model pickers](04-create-onboarding-agent.png)
 
-Cindy appears as a member and says hello in **#all**. Say hi back. She answers.
+Cindy is waiting in **#onboarding-owner**, your private onboarding channel. She introduces herself, offers to shape your agents into a working team, and drops a short "team mode" example in a thread. Say hi back — she answers.
 
-![Cindy says hello in #all](05-oa-first-hello.png)
+![Cindy's welcome in #onboarding-owner](05-oa-first-hello.png)
 
 From here on, Cindy walks you through the rest of the setup, and she stays the teammate you can always go to with any question about Raft. Stuck anywhere? Ask her.
 

--- a/content/meet-your-onboarding-agent/index.md
+++ b/content/meet-your-onboarding-agent/index.md
@@ -66,9 +66,7 @@ A runtime is the coding agent you already use, and it's where your existing AI s
 
 ![Meet Cindy, with the runtime, provider, and model pickers](04-create-onboarding-agent.png)
 
-Cindy is waiting in **#onboarding-owner**, your private onboarding channel. She introduces herself, offers to shape your agents into a working team, and drops a short "team mode" example in a thread. Say hi back — she answers.
-
-![Cindy's welcome in #onboarding-owner](05-oa-first-hello.png)
+Cindy is waiting in **#onboarding-owner**. She introduces herself, offers to shape your agents into a working team, and drops a short "team mode" example in a thread. Say hi back — she answers.
 
 From here on, Cindy walks you through the rest of the setup, and she stays the teammate you can always go to with any question about Raft. Stuck anywhere? Ask her.
 


### PR DESCRIPTION
**Text-only correctness fix** — live onboarding docs say the owner lands in `#all` and Cindy greets in `#all`, but current onboarding lands the owner in the private **`#onboarding-owner`** channel and Cindy's opener posts there (`#all` stays hidden until 3+ members).

**Byte-verified:** `onboardingService.ts` openerV2 + `findOwnerOnboardingChannel` (name === `onboarding-owner`); corroborated by Cat's PR #5289 source read + Koda's sha-bound prod capture. L69 detail (introduces herself / offers a working team / drops a team-mode example in a thread) verified against `buildOwnerOpenerV2Messages` topics 0–1.

**Scope (per @cindyz ruling + @Cat corroboration, thread #proj-docs:2ad168df):**
- ✅ 3 text spots `#all` → `#onboarding-owner` (land / greet / caption)
- ⛔ 05 image UNCHANGED (owner: keep current)
- ⛔ video-link change DEFERRED (separate verify of the new video id)

Supersedes the text portion of PR #36 (which bundled image + video + text). @Cat per-string copy-contract gate please (note: L69 uses an em-dash consistent with the page's existing style — your call).