### PR TITLE
docs(lwr): state the version floor for the App-management commands

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -118,7 +118,9 @@ Owning an app does not publish it or make it available on other servers — publ
 
 The rest of the surface is on the CLI too — inspect with `list` and `status`, manage the logo with `logo` and `clear-logo`, manage private share links with `share-link`, `share-link-status` and `revoke-share-link`, request Marketplace review with `request-publish` and `request-unpublish`, and remove an unpublished app with `delete`.
 
-Your installed CLI is the authority on what it exposes: run `raft integration app --help` and treat its `Commands:` list as definitive. Anything absent from that list returns `unknown command` and names the valid set.
+The App-management commands require **Raft Computer 1.0.15 or later** — that release added the whole `raft integration app` set. On an older build they are simply absent, so upgrade first.
+
+After that, your installed CLI is the authority on what it exposes: run `raft integration app --help` and treat its `Commands:` list as definitive. Anything absent from that list returns `unknown command` and names the valid set.
 
 ### The manual path
 

--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -118,7 +118,7 @@ Owning an app does not publish it or make it available on other servers — publ
 
 The rest of the surface is on the CLI too — inspect with `list` and `status`, manage the logo with `logo` and `clear-logo`, manage private share links with `share-link`, `share-link-status` and `revoke-share-link`, request Marketplace review with `request-publish` and `request-unpublish`, and remove an unpublished app with `delete`.
 
-The App-management commands require **Raft Computer 1.0.15 or later** — that release added the whole `raft integration app` set. On an older build they are simply absent, so upgrade first.
+**If a command documented here returns `unknown command`, your Raft Computer is older than the feature — upgrade and try again.** Capabilities land in the CLI release by release, so a build from before a feature shipped simply does not have it. The App-management set arrived in **1.0.15**.
 
 After that, your installed CLI is the authority on what it exposes: run `raft integration app --help` and treat its `Commands:` list as definitive. Anything absent from that list returns `unknown command` and names the valid set.
 

--- a/content/developers/raft-apps/build/index.md
+++ b/content/developers/raft-apps/build/index.md
@@ -64,7 +64,7 @@ Registration gives the app a client ID. The app owner can then generate a client
 
 Store the secret only on your server. Do not place it in browser JavaScript, screenshots, chat messages, source control, or agent instructions.
 
-An agent can prepare this registration: `raft integration app prepare register` posts a commit card that a server owner or admin approves once. Details in [Login with Raft → Registering your app](/developers/login-with-raft/#registering-your-app).
+An agent can prepare this registration: `raft integration app prepare register` posts a commit card that a server owner or admin approves once. Details in [Login with Raft → Registering your app](/developers/login-with-raft/#registering-your-app). If that command returns `unknown command`, the Raft Computer running the agent predates the feature — upgrade it.
 
 ## Wire the auth exchange
 


### PR DESCRIPTION
@cindyz's catch on #42: the page names the commands and points readers at their own `--help`, which tells them **whether** they have a command but not **how to get it**. A reader on an older build hits `unknown command` with no next step.

**Version is from the SoT, not inferred:** `agentDaemonReleaseNotes.ts` records daemon **1.0.15** with `capabilityId: integration-app-management`, listing all 15 subcommands in a single `new_capability` entry — so the floor is **1.0.15 for the whole set**, not per-command.

Kept the `--help` pointer after it, because the two answer different questions and the surface is still rolling:
- **floor** → which build do I need
- **pointer** → what does mine actually expose

Signed-off-by: Maggie <maggie@mail.build>