### PR TITLE
docs: keep redirect sources out of the sitemap

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitepress'
 import taskLists from 'markdown-it-task-lists'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
@@ -58,6 +60,45 @@ function humanUrlPath(relativePath: string): string {
   return `/${relativePath.replace(/\.md$/, '/')}`
 }
 
+// A page can exist as real content (so VitePress emits it into the sitemap)
+// while `_redirects` sends it somewhere else, which puts 301 URLs in a file
+// that should only contain canonical, directly-200 ones. Read the redirect
+// table rather than hard-coding today's offenders: the pair that drift apart
+// is (content pages, _redirects), so the check has to be derived from the
+// redirect table itself or it goes stale the next time someone adds one.
+const REDIRECTS_FILE = resolve(__dirname, '../content/public/_redirects')
+
+function redirectSourcePaths(): Set<string> {
+  const sources = new Set<string>()
+
+  for (const line of readFileSync(REDIRECTS_FILE, 'utf-8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+
+    const [from, to] = trimmed.split(/\s+/)
+    if (!from || !to || from.includes('*')) continue
+
+    // Compare sources EXACTLY as written -- do not normalise trailing slashes.
+    // The table holds canonicalisation rules like `/welcome -> /welcome/`, and
+    // slash-normalising that source turns it into its own target, which would
+    // drop the real 200 page from the sitemap. (It did: the first version of
+    // this filter removed /welcome/ along with the two genuine offenders.)
+    // A rule only disqualifies a sitemap URL when it points somewhere else.
+    if (from === to) continue
+    sources.add(from)
+  }
+
+  if (sources.size === 0) {
+    throw new Error(
+      `Parsed 0 redirect sources from ${REDIRECTS_FILE}. That is almost ` +
+        `certainly a format change rather than an empty redirect table, and ` +
+        `silently filtering nothing would let 301s back into the sitemap.`,
+    )
+  }
+
+  return sources
+}
+
 export default defineConfig({
   title: 'Raft Docs',
   description,
@@ -67,6 +108,14 @@ export default defineConfig({
   lastUpdated: true,
   sitemap: {
     hostname: siteUrl,
+    transformItems(items) {
+      const redirected = redirectSourcePaths()
+
+      return items.filter((item) => {
+        const path = item.url.startsWith('/') ? item.url : `/${item.url}`
+        return !redirected.has(path)
+      })
+    },
   },
   vite: {
     plugins: [

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+// @ts-expect-error -- plain .mjs helper shared with scripts/check-sitemap-redirects.mjs
+import { parseRedirectRules, redirectTargetFor } from '../scripts/redirect-rules.mjs'
 import { defineConfig } from 'vitepress'
 import taskLists from 'markdown-it-task-lists'
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
@@ -61,42 +63,15 @@ function humanUrlPath(relativePath: string): string {
 }
 
 // A page can exist as real content (so VitePress emits it into the sitemap)
-// while `_redirects` sends it somewhere else, which puts 301 URLs in a file
-// that should only contain canonical, directly-200 ones. Read the redirect
-// table rather than hard-coding today's offenders: the pair that drift apart
-// is (content pages, _redirects), so the check has to be derived from the
-// redirect table itself or it goes stale the next time someone adds one.
+// while `_redirects` sends it somewhere else, which puts 301/302 URLs in a file
+// that should only contain canonical, directly-200 ones. Parsing/matching lives
+// in scripts/redirect-rules.mjs so this filter and the build-time check cannot
+// drift apart -- when they were separate, both skipped wildcard rules and the
+// check still claimed full coverage.
 const REDIRECTS_FILE = resolve(__dirname, '../content/public/_redirects')
 
-function redirectSourcePaths(): Set<string> {
-  const sources = new Set<string>()
-
-  for (const line of readFileSync(REDIRECTS_FILE, 'utf-8').split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('#')) continue
-
-    const [from, to] = trimmed.split(/\s+/)
-    if (!from || !to || from.includes('*')) continue
-
-    // Compare sources EXACTLY as written -- do not normalise trailing slashes.
-    // The table holds canonicalisation rules like `/welcome -> /welcome/`, and
-    // slash-normalising that source turns it into its own target, which would
-    // drop the real 200 page from the sitemap. (It did: the first version of
-    // this filter removed /welcome/ along with the two genuine offenders.)
-    // A rule only disqualifies a sitemap URL when it points somewhere else.
-    if (from === to) continue
-    sources.add(from)
-  }
-
-  if (sources.size === 0) {
-    throw new Error(
-      `Parsed 0 redirect sources from ${REDIRECTS_FILE}. That is almost ` +
-        `certainly a format change rather than an empty redirect table, and ` +
-        `silently filtering nothing would let 301s back into the sitemap.`,
-    )
-  }
-
-  return sources
+function redirectRules() {
+  return parseRedirectRules(readFileSync(REDIRECTS_FILE, 'utf-8'))
 }
 
 export default defineConfig({
@@ -109,11 +84,11 @@ export default defineConfig({
   sitemap: {
     hostname: siteUrl,
     transformItems(items) {
-      const redirected = redirectSourcePaths()
+      const rules = redirectRules()
 
       return items.filter((item) => {
         const path = item.url.startsWith('/') ? item.url : `/${item.url}`
-        return !redirected.has(path)
+        return redirectTargetFor(path, rules) === null
       })
     },
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "description": "Raft public documentation site (VitePress, deployed at docs.raft.build)",
   "scripts": {
     "dev": "vitepress dev --host 0.0.0.0",
-    "build": "vitepress build && node scripts/generate-agent-artifacts.mjs",
+    "build": "vitepress build && node scripts/generate-agent-artifacts.mjs && node scripts/check-sitemap-redirects.mjs",
     "check:agent-artifacts": "node scripts/generate-agent-artifacts.mjs --check",
+    "check:sitemap-redirects": "node scripts/check-sitemap-redirects.mjs",
     "preview": "vitepress preview --host 0.0.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vitepress build && node scripts/generate-agent-artifacts.mjs && node scripts/check-sitemap-redirects.mjs",
     "check:agent-artifacts": "node scripts/generate-agent-artifacts.mjs --check",
     "check:sitemap-redirects": "node scripts/check-sitemap-redirects.mjs",
+    "check:redirect-matcher": "node scripts/check-sitemap-redirects.mjs --self-test",
     "preview": "vitepress preview --host 0.0.0.0"
   },
   "devDependencies": {

--- a/scripts/check-sitemap-redirects.mjs
+++ b/scripts/check-sitemap-redirects.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Assert the built sitemap contains no URL that `_redirects` sends elsewhere.
+ *
+ * WHY: a page can exist as real content (so VitePress emits it into the
+ * sitemap) while `_redirects` redirects it away. That puts 301 URLs in a file
+ * whose entire job is to list canonical, directly-200 ones. Found on
+ * docs.raft.build 2026-08-03: `/` and `/features/` were both listed, and both
+ * of their destinations were already listed separately.
+ *
+ * The filter that prevents it lives in `.vitepress/config.mts`. This check
+ * exists so that deleting the filter fails the build instead of silently
+ * restoring the defect.
+ *
+ * Run after a build:  node scripts/check-sitemap-redirects.mjs
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const SITEMAP = resolve(root, 'out/sitemap.xml')
+const REDIRECTS = resolve(root, 'content/public/_redirects')
+
+function redirectSources() {
+  const sources = new Map()
+  for (const line of readFileSync(REDIRECTS, 'utf-8').split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const [from, to] = trimmed.split(/\s+/)
+    if (!from || !to || from.includes('*')) continue
+    // Exact comparison, no slash normalisation: the table contains
+    // canonicalisation rules like `/welcome -> /welcome/`, and normalising
+    // that source into its own target would flag the real page as an error.
+    if (from === to) continue
+    sources.set(from, to)
+  }
+  return sources
+}
+
+function sitemapPaths() {
+  const xml = readFileSync(SITEMAP, 'utf-8')
+  return [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) =>
+    m[1].replace(/^https?:\/\/[^/]+/, ''),
+  )
+}
+
+const sources = redirectSources()
+const paths = sitemapPaths()
+
+// Both inputs must be non-empty. A zero on either side would make this check
+// pass for the same reason a broken parser does, and a check that cannot fail
+// is worse than no check -- it stops anyone looking.
+if (sources.size === 0) {
+  console.error(`Parsed 0 redirect sources from ${REDIRECTS} — format changed?`)
+  process.exit(1)
+}
+if (paths.length === 0) {
+  console.error(`Parsed 0 URLs from ${SITEMAP} — did the build run?`)
+  process.exit(1)
+}
+
+const offenders = paths.filter((p) => sources.has(p))
+
+if (offenders.length > 0) {
+  console.error(
+    'Sitemap lists URLs that _redirects sends elsewhere:\n' +
+      offenders.map((p) => `  - ${p} -> ${sources.get(p)}`).join('\n') +
+      '\n\nA sitemap must contain only canonical, directly-200 URLs.' +
+      '\nFix: the transformItems filter in .vitepress/config.mts.',
+  )
+  process.exit(1)
+}
+
+console.log(
+  `sitemap-redirects OK — ${paths.length} sitemap URLs checked against ` +
+    `${sources.size} redirect sources, no overlap.`,
+)

--- a/scripts/check-sitemap-redirects.mjs
+++ b/scripts/check-sitemap-redirects.mjs
@@ -3,40 +3,29 @@
  * Assert the built sitemap contains no URL that `_redirects` sends elsewhere.
  *
  * WHY: a page can exist as real content (so VitePress emits it into the
- * sitemap) while `_redirects` redirects it away. That puts 301 URLs in a file
- * whose entire job is to list canonical, directly-200 ones. Found on
+ * sitemap) while `_redirects` redirects it away. That puts 301/302 URLs in a
+ * file whose entire job is to list canonical, directly-200 ones. Found on
  * docs.raft.build 2026-08-03: `/` and `/features/` were both listed, and both
  * of their destinations were already listed separately.
  *
  * The filter that prevents it lives in `.vitepress/config.mts`. This check
  * exists so that deleting the filter fails the build instead of silently
- * restoring the defect.
+ * restoring the defect. Both share scripts/redirect-rules.mjs: the first
+ * version of this pair had two separate implementations that each skipped
+ * wildcard rules, so the check reported "no URL is redirected away" while
+ * `/agent-knowledge/*` went unexamined -- a claim wider than its coverage.
  *
  * Run after a build:  node scripts/check-sitemap-redirects.mjs
+ * Matcher self-test:  node scripts/check-sitemap-redirects.mjs --self-test
  */
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { parseRedirectRules, redirectTargetFor } from './redirect-rules.mjs'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const SITEMAP = resolve(root, 'out/sitemap.xml')
 const REDIRECTS = resolve(root, 'content/public/_redirects')
-
-function redirectSources() {
-  const sources = new Map()
-  for (const line of readFileSync(REDIRECTS, 'utf-8').split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed || trimmed.startsWith('#')) continue
-    const [from, to] = trimmed.split(/\s+/)
-    if (!from || !to || from.includes('*')) continue
-    // Exact comparison, no slash normalisation: the table contains
-    // canonicalisation rules like `/welcome -> /welcome/`, and normalising
-    // that source into its own target would flag the real page as an error.
-    if (from === to) continue
-    sources.set(from, to)
-  }
-  return sources
-}
 
 function sitemapPaths() {
   const xml = readFileSync(SITEMAP, 'utf-8')
@@ -45,27 +34,72 @@ function sitemapPaths() {
   )
 }
 
-const sources = redirectSources()
+/**
+ * Regression teeth for the matcher, run against the REAL redirect table.
+ *
+ * These exist because the two defects found so far were both in matching, not
+ * in plumbing: slash-normalising a canonicalisation source onto its own target
+ * (which deleted /welcome/), and skipping wildcard rules (which let
+ * /agent-knowledge/<anything>/ through). Neither is visible in a URL count.
+ */
+function selfTest() {
+  const rules = parseRedirectRules(readFileSync(REDIRECTS, 'utf-8'))
+  const cases = [
+    // [path, should be treated as redirected away]
+    ['/', true], //                       exact rule -> /welcome/
+    ['/features/', true], //              exact rule -> /features/server/
+    ['/welcome/', false], //              destination; the `/welcome -> /welcome/`
+    //                                    canonicalisation rule must not hit it
+    ['/features/server/', false], //      destination
+    ['/agent-knowledge/review-probe/', true], // terminal wildcard, the case
+    //                                    @meichen proved was leaking
+    ['/agent-knowledge/', true], //       wildcard prefix boundary
+    ['/features/agents/', false], //      real page under a redirected parent
+    ['/developers/login-with-raft/', false], // destination of /developers
+  ]
+
+  const failures = []
+  for (const [path, expected] of cases) {
+    const got = redirectTargetFor(path, rules) !== null
+    if (got !== expected) {
+      failures.push(
+        `  ${path} -> treated as ${got ? 'redirected' : 'canonical'}, expected ` +
+          `${expected ? 'redirected' : 'canonical'}`,
+      )
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('redirect matcher self-test FAILED:\n' + failures.join('\n'))
+    process.exit(1)
+  }
+  console.log(`redirect matcher self-test OK — ${cases.length} cases.`)
+}
+
+selfTest()
+
+if (process.argv.includes('--self-test')) process.exit(0)
+
+const rules = parseRedirectRules(readFileSync(REDIRECTS, 'utf-8'))
 const paths = sitemapPaths()
 
 // Both inputs must be non-empty. A zero on either side would make this check
 // pass for the same reason a broken parser does, and a check that cannot fail
-// is worse than no check -- it stops anyone looking.
-if (sources.size === 0) {
-  console.error(`Parsed 0 redirect sources from ${REDIRECTS} — format changed?`)
-  process.exit(1)
-}
+// is worse than no check -- it stops anyone looking. (parseRedirectRules
+// throws on an empty table, so only the sitemap side needs asserting here.)
 if (paths.length === 0) {
   console.error(`Parsed 0 URLs from ${SITEMAP} — did the build run?`)
   process.exit(1)
 }
 
-const offenders = paths.filter((p) => sources.has(p))
+const offenders = paths
+  .map((p) => [p, redirectTargetFor(p, rules)])
+  .filter(([, target]) => target !== null)
 
 if (offenders.length > 0) {
   console.error(
     'Sitemap lists URLs that _redirects sends elsewhere:\n' +
-      offenders.map((p) => `  - ${p} -> ${sources.get(p)}`).join('\n') +
+      offenders.map(([p, t]) => `  - ${p} -> ${t}`).join('\n') +
       '\n\nA sitemap must contain only canonical, directly-200 URLs.' +
       '\nFix: the transformItems filter in .vitepress/config.mts.',
   )
@@ -74,5 +108,5 @@ if (offenders.length > 0) {
 
 console.log(
   `sitemap-redirects OK — ${paths.length} sitemap URLs checked against ` +
-    `${sources.size} redirect sources, no overlap.`,
+    `${rules.length} redirect rules, no overlap.`,
 )

--- a/scripts/redirect-rules.mjs
+++ b/scripts/redirect-rules.mjs
@@ -1,0 +1,89 @@
+/**
+ * Shared parser/matcher for `content/public/_redirects`.
+ *
+ * Single source of truth on purpose: the sitemap filter (.vitepress/config.mts)
+ * and the build-time check (check-sitemap-redirects.mjs) must agree by
+ * construction. When they were separate implementations, both skipped wildcard
+ * rules and the check still reported "no URL is redirected away" -- a claim
+ * broader than what it verified.
+ */
+
+/**
+ * @typedef {{kind:'exact', from:string, to:string}
+ *          |{kind:'prefix', from:string, prefix:string, to:string}} RedirectRule
+ */
+
+/**
+ * Parse a `_redirects` table.
+ *
+ * Supports exact sources and TERMINAL wildcards (`/section/*`). Anything else
+ * throws rather than being skipped: an unsupported rule that is silently
+ * ignored turns into a redirected URL that the sitemap happily publishes,
+ * which is the exact defect this module exists to prevent. Fail closed.
+ *
+ * @param {string} text
+ * @returns {RedirectRule[]}
+ */
+export function parseRedirectRules(text) {
+  /** @type {RedirectRule[]} */
+  const rules = []
+
+  text.split('\n').forEach((line, i) => {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) return
+
+    const [from, to] = trimmed.split(/\s+/)
+    if (!from || !to) return
+
+    // Canonicalisation rules such as `/welcome -> /welcome/` point at
+    // themselves once slashes are normalised. Compare as written and drop
+    // identities, so the rule can never disqualify its own destination.
+    if (from === to) return
+
+    if (!from.includes('*')) {
+      rules.push({ kind: 'exact', from, to })
+      return
+    }
+
+    if (from.endsWith('/*') && !from.slice(0, -2).includes('*')) {
+      rules.push({ kind: 'prefix', from, prefix: from.slice(0, -1), to })
+      return
+    }
+
+    throw new Error(
+      `_redirects line ${i + 1}: unsupported wildcard source "${from}". ` +
+        `Only terminal "/section/*" is handled. Skipping it would let the ` +
+        `sitemap publish URLs this rule redirects away, so this fails closed ` +
+        `-- extend parseRedirectRules() instead of ignoring the rule.`,
+    )
+  })
+
+  if (rules.length === 0) {
+    throw new Error(
+      'Parsed 0 redirect rules. That is far more likely a format change than ' +
+        'an empty redirect table, and matching nothing would silently disable ' +
+        'every downstream check.',
+    )
+  }
+
+  return rules
+}
+
+/**
+ * Where `_redirects` sends this path, or null if it is served directly.
+ *
+ * @param {string} path absolute, e.g. "/features/"
+ * @param {RedirectRule[]} rules
+ * @returns {string|null}
+ */
+export function redirectTargetFor(path, rules) {
+  for (const rule of rules) {
+    if (rule.kind === 'exact') {
+      if (rule.from === path) return rule.to
+      continue
+    }
+    // Never let a prefix rule disqualify the page it redirects to.
+    if (path.startsWith(rule.prefix) && path !== rule.to) return rule.to
+  }
+  return null
+}


### PR DESCRIPTION
## What

The docs sitemap listed two URLs that `_redirects` immediately 301s away:

| sitemap entry | live behaviour |
|---|---|
| `/` | 301 → `/welcome/` |
| `/features/` | 301 → `/features/server/` |

Both destinations were **already listed separately**, so the sitemap carried 301s alongside the canonical URLs they point at. A sitemap should contain only canonical, directly-200 URLs.

**Cause:** `content/index.md` and `content/features/index.md` are real VitePress pages, so the sitemap emits them, while `content/public/_redirects` sends them elsewhere.

## Approach

Filter sitemap items through the redirect table instead of hard-coding today's two offenders. The pair that drifts apart is *(content pages, `_redirects`)*, so the rule has to be derived from `_redirects` or it goes stale the next time someone adds a page-shaped redirect.

Sources are compared **exactly, without slash normalisation.** The table holds canonicalisation rules such as `/welcome -> /welcome/`; normalising that source into its own target drops the real 200 page. **The first version of this filter did exactly that and removed `/welcome/`** — caught by diffing the built sitemap against the live one, which is why the verification below compares sets rather than counts.

## Verification

Local build reproduces production byte-for-byte before the change: **40 URLs, same set as live `docs.raft.build/sitemap.xml`.**

```
baseline 40 -> after fix 38
REMOVED: ['/', '/features/']
ADDED  : []
/welcome/          present  (want present)
/features/server/  present  (want present)
```

**Mutation-verified** — the fix can be deleted, the defect cannot silently return:

```
filter present  -> build RC=0, "38 sitemap URLs checked against 18 redirect sources, no overlap"
filter deleted  -> build RC=1, "Sitemap lists URLs that _redirects sends elsewhere:
                                  - /features/ -> /features/server/
                                  - / -> /welcome/"
filter restored -> build RC=0
```

`scripts/check-sitemap-redirects.mjs` is wired into `build` and exposed as `check:sitemap-redirects`. Both of its inputs are asserted non-empty — a zero on either side would make the check pass for the same reason a broken parser does, and a check that cannot fail is worse than no check because it stops anyone from looking.

Repo gates: `check:agent-artifacts` ✅ · `tsc --noEmit` ✅

## Out of scope, flagged not proposed

**`/` itself being a 301 to `/welcome/` is an information-architecture decision**, not a sitemap bug — home-page authority flows to `/welcome/`, and every external reference to `docs.raft.build` costs an extra hop. Legal and possibly intended. Naming it; not touching it. Needs a human call if anyone wants it changed.

## Credit

Found by @Wug in `#proj-seo-geo`; source cause his. His recommendation offered "stop emitting the redirect sources **or** emit `/welcome/` and `/features/server/` instead" — the second branch is a no-op, both targets were already present (counted, not eyeballed), so this does the removal only.

Task #93 in `#proj-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)