### PR TITLE
docs(apps): clarify private sharing during review

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -479,12 +479,15 @@ Membership alone grants nothing. Fail closed. If humans and agents get different
 
 ### App availability
 
-Developer-created apps reach a server in one of two ways:
+Developer-created apps reach a server in one of three ways:
 
 | Availability | Who creates it | How users reach it |
 | --- | --- | --- |
 | Server-local app | A developer prepares it; a server owner or admin authorizes and commits the registration | Private to that server. |
+| Private-shared app | The app owner creates a private share link | A server owner or admin installs it from the link. Only the source server and servers with an install can discover or use it. |
 | Published third-party app | Outside developers, after Raft review | A server admin installs it. Uninstalling revokes all grants and tokens for that server. |
+
+Private sharing and Marketplace review are independent. Requesting publication, waiting for review, or receiving a rejection does not revoke existing private installs, grants, tokens, or valid share links. The app remains hidden from servers that do not have an install or share link. Publication controls public Marketplace discovery; uninstalling from a server still revokes that server's grants and tokens.
 
 The server picker during login only surfaces servers where the app is available. If a user doesn't see a server they expect, the app may not be installed there.
 

--- a/content/features/apps/index.md
+++ b/content/features/apps/index.md
@@ -16,7 +16,7 @@ The app receives your Raft identity and server context — not access to your me
 
 ## Types of apps
 
-There are three kinds of connected apps:
+There are four ways a connected app can be available:
 
 ### Built-in apps
 
@@ -32,6 +32,12 @@ Use server-local apps for internal tools — a team dashboard, a content calenda
 
 Server-local apps can be **published to the marketplace** if the creator wants to make them available to other servers. This requires a review by Raft before the app becomes publicly listed.
 
+### Private-shared apps
+
+An app owner can share an app directly with another server without listing it in the public marketplace. A server owner or admin installs it from the private share link. Only the source server and servers with an install can discover or use it.
+
+Private installs are independent from Marketplace review. Requesting publication or receiving a rejection does not remove existing installs or make the app public. Installed servers keep access until they uninstall it; servers without an install or valid share link still cannot discover it.
+
 ### Third-party marketplace apps
 
 Third-party apps are built by outside developers, reviewed by Raft, and published to the marketplace. A server owner or admin installs them before they're available to members.
@@ -43,7 +49,7 @@ The same app can be installed by many servers, but each server's connection is i
 Server owners and admins manage connected apps from **Settings → Connected Apps**, which has three tabs:
 
 - **Marketplace** — browse built-in apps and reviewed third-party listings. Search, filter, and view app details before installing.
-- **Installed** — apps currently connected to your server, including marketplace installs and server-local apps. Uninstall apps here.
+- **Installed** — apps currently connected to your server, including marketplace installs, private-shared installs, and server-local apps. Uninstall apps here.
 - **My Apps** — apps registered by your server. Edit metadata, manage credentials, or request marketplace publication.
 
 ![Connected Apps settings — the Marketplace tab, with the built-in band and reviewed third-party listings](./01-connected-apps-marketplace.png)
@@ -74,9 +80,9 @@ If you are building the app, start with the developer guide: [Raft Apps](/develo
 
 ## Agent access
 
-Agents can use connected apps just like humans. When an app is available to the server — because it is built in, server-local, or an installed marketplace app — Raft grants the agent access when it signs in. There is no separate per-agent approval card.
+Agents can use connected apps just like humans. When an app is available to the server — because it is built in, server-local, privately shared and installed, or installed from the marketplace — Raft grants the agent access when it signs in. There is no separate per-agent approval card.
 
-Marketplace installation is the human authorization boundary: a server owner or admin must install the app before any member or agent on that server can use it. A marketplace app that has not been installed fails closed.
+Installation is the human authorization boundary: a server owner or admin must install a private-shared or marketplace app before any member or agent on that server can use it. An app that is not local, built in, or installed fails closed.
 
 Each agent grant is still specific to one agent, app, and server. It does not give another agent access, extend to another app, or apply to another server.
 


### PR DESCRIPTION
## Summary

- add private-shared apps to the public availability model
- document that Marketplace review/rejection does not revoke private installs, grants, tokens, or valid share links
- keep public discovery and per-server uninstall boundaries explicit

## Production source

Documents behavior shipped in `botiverse/slock` production commit `5b4c8b7d15df4b4453f5690098ba3b57a33ec321` (PR #5963).

## Validation

- `pnpm build`
- `pnpm check:agent-artifacts`
- `git diff --check`

## Review

Please review the product contract, implementation match, and public wording. Do not merge without explicit human approval.
