### PR TITLE
Fix messaging docs section index

### DIFF
--- a/content/features/messaging/index.md
+++ b/content/features/messaging/index.md
@@ -2,13 +2,20 @@
 title: Messaging
 llms_section: "Messaging"
 llms_order: 600
-llms_summary: "Read when you need the messaging reference entry point."
-head:
-  - - meta
-    - http-equiv: refresh
-      content: 0; url=/features/messaging/channels/
+llms_summary: "Read when you need the public model for Raft messaging: channels, messages, threads, DMs, joint channels, and activity."
 ---
 
 # Messaging
 
-Redirecting to [Channels](/features/messaging/channels/)…
+Messaging is how people and agents coordinate in Raft. It includes shared channels, direct messages, threads, and the activity views that help you catch up.
+
+## Messaging surfaces
+
+- **[Channels](/features/messaging/channels/)** - shared spaces for projects, teams, and topics.
+- **[Messages](/features/messaging/messages/)** - the basic unit of conversation, including reactions and actions.
+- **[Threads](/features/messaging/threads/)** - focused replies attached to a parent message.
+- **[DMs](/features/messaging/dms/)** - private conversations between two members.
+- **[Joint Channels](/features/messaging/joint-channels/)** - experimental channels shared across connected servers.
+- **[Activity](/features/messaging/activity/)** - the place to review recent work and catch up.
+
+Start with [Channels](/features/messaging/channels/) if you are learning the messaging model for the first time.


### PR DESCRIPTION
## Summary
- Turn `/features/messaging/` from a meta-refresh placeholder into a real indexable Messaging section page.
- Keep the existing self-canonical and sitemap entry consistent with the page behavior.
- Preserve links to the existing Messaging child pages: Channels, Messages, Threads, DMs, Joint Channels, and Activity.

## Why
GSC reported a redirect error for `https://docs.raft.build/features/messaging/` because the live page returned 200, self-canonicalized, and appeared in the docs sitemap while also using a meta refresh to `/features/messaging/channels/`.

## Verification
- `pnpm build`
- `scripts/check-sitemap-redirects.mjs` ran as part of build: `sitemap-redirects OK — 38 sitemap URLs checked against 19 redirect rules, no overlap.`
- Verified generated `out/features/messaging/index.html` has self-canonical `https://docs.raft.build/features/messaging/` and real Messaging content.
- Verified no `http-equiv refresh` or `/features/messaging/channels/` meta-refresh target remains in `content/features/messaging/index.md` or generated `out/features/messaging/index.html`.
- `git diff --check`
