### PR TITLE
Fix collaboration docs index crawlability

### DIFF
--- a/content/features/collaboration/index.md
+++ b/content/features/collaboration/index.md
@@ -2,13 +2,17 @@
 title: Collaboration
 llms_section: "Collaboration"
 llms_order: 700
-llms_summary: "Read when you need the collaboration reference entry point."
-head:
-  - - meta
-    - http-equiv: refresh
-      content: 0; url=/features/collaboration/tasks/
+llms_summary: "Read when you need the collaboration reference entry point: tasks, files, and comments."
 ---
 
 # Collaboration
 
-Redirecting to [Tasks](/features/collaboration/tasks/)…
+Collaboration is how work in Raft moves from conversation into durable shared objects. It includes tasks for accountable work, files for shared context, and comments for focused feedback on artifacts.
+
+## Collaboration surfaces
+
+- **[Tasks](/features/collaboration/tasks/)** - turn messages into trackable work with assignees, status, and review handoffs.
+- **[Files](/features/collaboration/files/)** - share attachments so people and agents can work from the same context.
+- **[Comments on files](/features/collaboration/comments/)** - anchor feedback to a specific line, row, region, or moment in a shared file.
+
+Start with [Tasks](/features/collaboration/tasks/) if you are coordinating a piece of work for the first time.


### PR DESCRIPTION
## Summary
- Replace the sitemap-listed `/features/collaboration/` meta-refresh stub with a real Collaboration section landing page.
- Link the section index to Tasks, Files, and Comments on files.
- Keep `/features/collaboration/` as an indexable self-canonical URL instead of redirecting users/crawlers to Tasks.

## Verification
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:sitemap-redirects`
- `pnpm check:redirect-matcher`
- `rg -n "http-equiv=|refresh|Redirecting to \[Tasks\]|Redirecting to Tasks|url=/features/collaboration/tasks" out/features/collaboration/index.html` -> no matches
- `rg -n "Collaboration surfaces|Tasks|Files|Comments on files" out/features/collaboration/index.html`
- `rg -n "https://docs\.raft\.build/features/collaboration/" out/sitemap.xml`
- `git diff --check origin/main..HEAD`