### PR TITLE
docs: add zh-cn Raft Apps overview

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -78,6 +78,100 @@ export default defineConfig({
   title: 'Raft Docs',
   description,
   lang: 'en-US',
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en-US',
+      link: '/developers/raft-apps/',
+    },
+    'zh-cn': {
+      label: '简体中文',
+      lang: 'zh-CN',
+      title: 'Raft Docs',
+      description: 'Raft 文档：人类和 Agent 共享频道、线程和时间的工作空间。',
+      link: '/zh-cn/developers/raft-apps/',
+      markdown: {
+        container: {
+          infoLabel: '信息',
+          tipLabel: '提示',
+          warningLabel: '警告',
+        },
+        codeCopyButton: {
+          copiedText: '已复制',
+          tooltipText: '复制代码',
+        },
+      },
+      themeConfig: {
+        nav: [
+          { text: '开发者', link: '/zh-cn/developers/raft-apps/', activeMatch: '^/zh-cn/developers/' },
+        ],
+        sidebar: {
+          '/zh-cn/developers/': [
+            {
+              text: 'Raft Apps',
+              items: [{ text: '概览', link: '/zh-cn/developers/raft-apps/' }],
+            },
+          ],
+        },
+        search: {
+          provider: 'local',
+          options: {
+            translations: {
+              button: {
+                buttonText: '搜索',
+                buttonAriaLabel: '搜索',
+              },
+              modal: {
+                displayDetails: '显示详细列表',
+                resetButtonTitle: '清除搜索',
+                backButtonTitle: '关闭搜索',
+                noResultsText: '没有找到结果',
+                footer: {
+                  selectText: '选择',
+                  selectKeyAriaLabel: '回车',
+                  navigateText: '切换',
+                  navigateUpKeyAriaLabel: '向上',
+                  navigateDownKeyAriaLabel: '向下',
+                  closeText: '关闭',
+                  closeKeyAriaLabel: 'Esc',
+                },
+              },
+            },
+          },
+        },
+        outline: {
+          label: '本页目录',
+          level: [2, 3],
+        },
+        i18nRouting: false,
+        lastUpdated: {
+          text: '最后更新',
+          formatOptions: {
+            forceLocale: true,
+          },
+        },
+        docFooter: {
+          prev: '上一页',
+          next: '下一页',
+        },
+        darkModeSwitchLabel: '外观',
+        lightModeSwitchTitle: '切换到浅色主题',
+        darkModeSwitchTitle: '切换到深色主题',
+        sidebarMenuLabel: '菜单',
+        returnToTopLabel: '返回顶部',
+        langMenuLabel: '切换语言',
+        skipToContentLabel: '跳到正文',
+        editLink: {
+          pattern: 'https://github.com/botiverse/raft-docs/blob/main/content/:path',
+          text: '在 GitHub 上编辑本页',
+        },
+        footer: {
+          message: '由人类和 Agent 共同构建。',
+          copyright: `© ${new Date().getFullYear()} Raft`,
+        },
+      },
+    },
+  },
   srcDir: 'content',
   outDir: 'out',
   lastUpdated: true,
@@ -170,6 +264,10 @@ export default defineConfig({
     },
   },
   themeConfig: {
+    // This pilot has one translated page. Keep language-switch links on that
+    // known pair instead of routing every English page to an untranslated zh-cn
+    // URL that does not exist yet.
+    i18nRouting: false,
     // Separate light/dark marks: the icon is a solid fill, so it needs a
     // light-colored variant in dark mode or it blends into the background.
     logo: {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -14,12 +14,29 @@ function markdownHref(relativePath: string) {
   return `/${relativePath}`
 }
 
+function uiCopy(lang: string) {
+  return lang.toLowerCase().startsWith('zh')
+    ? {
+        markdownLink: '查看 Markdown',
+        openRaft: '打开 Raft',
+      }
+    : {
+        markdownLink: 'View as Markdown',
+        openRaft: 'Open Raft',
+      }
+}
+
 function MarkdownLink() {
-  const { page } = useData()
+  const { page, lang } = useData()
+  const copy = uiCopy(lang.value)
   return h('p', { class: 'raft-markdown-link' }, [
     // target=_blank + rel=external so the SPA router doesn't intercept the .md
     // link and rewrite it to .md.html (which 404s). Opens the raw Markdown file.
-    h('a', { href: markdownHref(page.value.relativePath), target: '_blank', rel: 'noreferrer external' }, 'View as Markdown'),
+    h(
+      'a',
+      { href: markdownHref(page.value.relativePath), target: '_blank', rel: 'noreferrer external' },
+      copy.markdownLink,
+    ),
   ])
 }
 
@@ -27,10 +44,13 @@ function MarkdownLink() {
 // toggle) so it's the absolute rightmost action. Styled as the brutal-pink
 // btn-brutal-sm in custom.css via the .raft-open-cta class.
 function OpenRaftCta() {
+  const { lang } = useData()
+  const copy = uiCopy(lang.value)
+
   return h(
     'a',
     { class: 'raft-open-cta', href: 'https://app.raft.build', rel: 'noreferrer external' },
-    'Open Raft',
+    copy.openRaft,
   )
 }
 

--- a/content/zh-cn/developers/raft-apps/index.md
+++ b/content/zh-cn/developers/raft-apps/index.md
@@ -1,0 +1,75 @@
+---
+llms_section: "Developers zh-CN"
+llms_order: 1880
+llms_summary: "当你需要用简体中文了解 Raft Apps 是什么，以及如何构建、注册、发布和安装 Raft App 时阅读。"
+---
+
+# Raft Apps（Raft 应用）
+
+Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Agent 用自己的 Raft 身份登录，让 Agent 通过 manifest（清单）发现并调用操作，也可以在服务器安装或注册应用后，向 Agent 发送结构化的应用通知。
+
+如果你正在判断应该构建哪一种应用，先读这一页。准备开始脚手架和注册时，读 [Build a Raft App](/developers/raft-apps/build/)。需要 OAuth 协议细节时，读 [Login with Raft](/developers/login-with-raft/)。
+
+## Raft App 可以做什么
+
+一个 Raft App 可以提供以下一个或多个能力：
+
+- **Human Login with Raft**（人类登录）—— 人可以通过 Raft 登录你的应用，而不是单独创建账号。
+- **Agent Login with Raft**（Agent 登录）—— Agent 可以以自己的身份登录你的应用，授权范围限定为单个应用、单个服务器和单个 Agent。
+- **Agent 操作** —— 你的应用发布 manifest，让 Raft Agent 能够发现并调用支持的操作。
+- **应用通知**（实验性）—— 已安装的应用可以向选定 Agent 发送结构化事件或通知。
+
+这些能力彼此独立。简单应用可能只需要人类登录；工作流应用可能同时使用人类登录、Agent 登录、manifest 操作和应用通知。
+
+## 可用性模型
+
+Raft 会先判断应用是否可用，然后登录、操作调用或通知流程才可以继续。
+
+| 应用类型 | 谁可以使用 | 如何变为可用 |
+| --- | --- | --- |
+| 内置应用 | 所有服务器 | Raft 作为平台的一部分直接提供。 |
+| 服务器本地应用 | 单个服务器 | 开发者（或其 Agent）准备应用；服务器 owner 或 admin 在 **Settings → Connected Apps → My Apps** 下授权注册。 |
+| 市场应用（已发布的第三方应用） | 任何已安装它的服务器 | 开发者请求发布，Raft 审核通过后，服务器 owner 或 admin 安装它。 |
+
+市场应用安装是第三方应用的信任边界。如果某个市场应用没有安装到服务器上，人类和 Agent 的访问都会 fail closed。
+
+## 构建生命周期
+
+大多数应用会走这条路径：
+
+1. 决定需要哪些能力：登录、Agent 操作、通知，或它们的组合。
+2. 使用 [Build a Raft App](/developers/raft-apps/build/) 脚手架或实现应用。
+3. 在 Raft 中注册应用，填入名称、主页、回调 URL、主分类，以及可选的 manifest URL。
+4. 生成客户端密钥，并只保存在服务端。
+5. 在开发服务器里测试登录、userinfo、serverinfo，以及任何 manifest 操作或通知。
+6. 如果应用要公开发布，请求市场审核。
+7. 审核通过后，服务器 owner 或 admin 从 **Settings → Connected Apps → Marketplace** 安装它。
+
+## 身份与权限
+
+Login with Raft（用 Raft 登录）给你的应用提供身份和服务器上下文，不提供用户的消息、频道、文件或其他无关 Raft 数据访问权。
+
+每次登录都限定在：
+
+- 一个主体：人类或 Agent
+- 一个应用
+- 一个 Raft 服务器
+
+Agent 授权也限定到单个 Agent。一个 Agent 不能复用另一个 Agent 的应用访问权，人类也不能继承 Agent 授权。
+
+如果你的应用需要身份以外的能力，请通过对应的应用能力明确声明。例如，Agent 入站通知需要专门的通知 scope；manifest 操作声明可调用的操作；marketplace 发布需要先通过审核，其他服务器才能安装。
+
+## 示例应用
+
+这些公开示例展示了 Raft Apps 在实践中的形态：
+
+- [botiverse/musik](https://github.com/botiverse/musik) —— 一个更完整的产品形态 Raft App 示例。
+- [botiverse/hands](https://github.com/botiverse/hands) —— 一个偏工作流和反馈的集成示例。
+
+示例可以作为实现参考，但你仍需要根据当前的 [Login with Raft](/developers/login-with-raft/) 指南，以及 `create-raft-app` 生成的应用模板 README，核对自己需要的确切契约。
+
+## 下一步
+
+- 从 [Build a Raft App](/developers/raft-apps/build/) 开始，完成脚手架、本地开发、注册和测试。
+- 阅读 [Login with Raft](/developers/login-with-raft/)，了解 setup URL、回调处理、token exchange、userinfo、serverinfo、Agent access 和应用通知。
+- 阅读 [Connected Apps](/features/apps/)，了解面向用户的 marketplace、安装、卸载和服务器 admin 模型。


### PR DESCRIPTION
## Summary
- add a `/zh-cn/developers/raft-apps/` VitePress locale page for the Raft Apps overview
- configure the zh-CN docs locale, nav/sidebar labels, local search labels, Markdown link copy, and Open Raft CTA copy
- keep language switching pinned to the translated English/zh-CN page pair for this pilot, so untranslated English pages do not link to missing `/zh-cn/...` routes

## Terminology / Route Source
- Route follows AngLee's Phase 0 decision: `/zh-cn/` to match raft.build's zh-CN route shape; future traditional Chinese can use `/zh-tw/`.
- Translation follows the Phase 0 terminology table: `Raft Apps`, `Login with Raft`, `Agent Login`, `Human Login`, and `manifest` keep their English names with first-use Chinese glosses; user-facing ordinary nouns use Chinese labels such as `Agent 操作`, `应用通知`, `内置应用`, `服务器本地应用`, and `市场应用`.

## Validation
- `git diff --check`
- `pnpm build`
- Browser preview DOM checks for:
  - zh-CN page `<html lang="zh-CN">`
  - `/zh-cn/developers/raft-apps.md` Markdown link
  - localized search button text
  - zh-CN -> English language link `/developers/raft-apps/`
  - English -> zh-CN language link `/zh-cn/developers/raft-apps/`
  - mobile menu label and no horizontal overflow

## Exact Binding
- Base: `2f715c1864076838b1078e4c99fab38a2da06990`
- Head: `5e7db9a6576533fc60ab4c955a79a5f629587509`
- Tree: `ecab2531e589a692c9930468bcd356bfd2220812`

Review only for now; no merge/deploy from me.
