### PR TITLE
docs: add zh-cn start pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -82,14 +82,14 @@ export default defineConfig({
     root: {
       label: 'English',
       lang: 'en-US',
-      link: '/developers/raft-apps/',
+      link: '/welcome/',
     },
     'zh-cn': {
       label: '简体中文',
       lang: 'zh-CN',
       title: 'Raft Docs',
       description: 'Raft 文档：人类和 Agent 共享频道、线程和时间的工作空间。',
-      link: '/zh-cn/developers/raft-apps/',
+      link: '/zh-cn/welcome/',
       markdown: {
         container: {
           infoLabel: '信息',
@@ -103,9 +103,19 @@ export default defineConfig({
       },
       themeConfig: {
         nav: [
+          { text: '开始', link: '/zh-cn/welcome/', activeMatch: '^/zh-cn/(?!developers/)' },
           { text: '开发者', link: '/zh-cn/developers/raft-apps/', activeMatch: '^/zh-cn/developers/' },
         ],
         sidebar: {
+          '/zh-cn/': [
+            {
+              text: '开始',
+              items: [
+                { text: 'Raft Docs', link: '/zh-cn/' },
+                { text: '欢迎使用 Raft', link: '/zh-cn/welcome/' },
+              ],
+            },
+          ],
           '/zh-cn/developers/': [
             {
               text: 'Raft Apps',

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -7,6 +7,8 @@ import './custom.css'
 import { initAnalytics } from './analytics'
 
 const translatedZhPaths = new Set([
+  '/zh-cn/',
+  '/zh-cn/welcome/',
   '/zh-cn/developers/raft-apps/',
   '/zh-cn/developers/raft-apps/build/',
   '/zh-cn/developers/login-with-raft/',

--- a/content/zh-cn/index.md
+++ b/content/zh-cn/index.md
@@ -1,0 +1,17 @@
+---
+title: Raft Docs（中文）
+description: Raft 文档。
+llms_section: "Start here zh-CN"
+llms_order: 1010
+llms_summary: "当 Agent 或爬虫需要简体中文公共文档入口，以及 Markdown 发现链接时先读。"
+---
+
+# Raft Docs（中文）
+
+从 [欢迎使用 Raft](/zh-cn/welcome/) 开始。
+
+## Agent 可读文档
+
+Agent、爬虫和工具可以从 [/zh-cn/llms.txt](/zh-cn/llms.txt) 开始。它会列出每个已翻译的中文公共文档页面，提供简短路由提示，并链接到每页的 Markdown twin。
+
+每个公共文档页面也会在 HTML head 里用 `rel="alternate"` 和 `type="text/markdown"` 标出自己的 Markdown twin，所以 Agent 可以从页面本身发现源格式。

--- a/content/zh-cn/welcome/index.md
+++ b/content/zh-cn/welcome/index.md
@@ -1,0 +1,42 @@
+---
+title: 欢迎使用 Raft
+description: 了解 Raft 如何让人类和 AI Agent 一起工作。
+llms_section: "Start here zh-CN"
+llms_order: 1020
+llms_summary: "当你需要用简体中文了解 Raft 是人类和 AI Agent 一起工作的空间时先读。"
+---
+
+# 欢迎使用 Raft
+
+Raft 是人类和 AI Agent 一起工作的地方。
+
+这里的 Agent 是房间里的真实队友。它们有持久身份，会记忆和学习，也会彼此对话、协作。
+
+人类仍在对话里，负责设定方向，并在需要时掌舵。
+
+一起搭好你的 Raft。
+
+## 开始使用
+
+**[认识你的 Onboarding Agent](/meet-your-onboarding-agent/)**
+创建服务器，连接一台 Computer，并认识你团队里的第一个 Agent。
+
+**[交接你的第一个任务](/hand-off-your-first-task/)**
+把真实工作交给 Agent，看它带着结果回来。
+
+**[邀请你的队友](/bring-in-your-teammates/)**
+邀请人类进入同一个房间，和 Agent 并肩工作。
+
+**[把 Raft 安装到手机上](/raft-on-every-device/)**
+把 Raft 加到主屏幕，让你的团队随时一键可达。
+
+**[组建你的 Agent 团队](/build-your-agent-team/)**
+添加更多 Agent，塑造每个 Agent 的职责，并培养一个会学习的团队。
+
+## 联系我们
+
+我们公开构建 Raft。塑造它最快的方法，就是直接和我们聊。
+
+- **Community**：[加入我们的社区服务器](https://app.raft.build/join/2ygbinDD9pvXuySuJrSEjg)，和团队及其他构建者聊聊。
+- **X**：关注 [@raft_hq](https://x.com/raft_hq)，获取更新和发布记录。
+- **LinkedIn**：[Raft on LinkedIn](https://www.linkedin.com/company/rafthq)


### PR DESCRIPTION
## Summary
- add the zh-CN docs entry page at `/zh-cn/`
- add the zh-CN welcome page at `/zh-cn/welcome/`
- move the default locale switch fallback from the Raft Apps pilot to the Start-here pages and include the new zh paths in exact language-switch rewrites
- keep `/zh-cn/llms.txt` as the zh-CN agent discovery surface, now with a separate `Start here zh-CN` section

## Scope notes
- This PR intentionally keeps the next-step links on `/zh-cn/welcome/` pointing to the existing English pages until those pages are translated in later slices, so the new page does not introduce dead zh-CN links.
- This does not change the English content pages beyond the locale switch fallback target.

## Exact binding
- B: `078c9fbbbae54aac0e1506507da747a3ba0cbbbc`
- H: `872eed3dea36cabac29c4914d8ea23bb4672a0cc`
- T: `34313fca7a42db75ecc88464579be1e53a857f15`

## Validation
- `pnpm build`
- `pnpm check:agent-artifacts`
- `git diff --check`
- focused readback: built zh pages expose `lang="zh-CN"`, `/zh-cn/llms.txt`, `/zh-cn/welcome/`, `欢迎使用 Raft`, `社区服务器`, and `发布记录`
- focused readback: root `out/llms.txt` has no `zh-cn`, `Raft Docs（中文）`, or `欢迎使用 Raft` hits
