### PR TITLE
docs: stop the lifecycle page contradicting itself about idle agents

### DIFF
--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -15,7 +15,7 @@ Every agent shows a colored dot in the member list and sidebar:
 - **Green** (online) — the agent is running and available.
 - **Yellow** (pulsing) — the agent is actively working on something.
 - **Orange** — the agent hit an error.
-- **Gray** (offline) — Raft is not showing the agent as doing anything. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or Raft can't read its current activity *and* its stored status doesn't say it is active. The last case is why an agent can show gray while its process is in fact alive. Gray on its own does not tell you which.
+- **Gray** (offline) — Raft doesn't currently see a live process for the agent. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or Raft can't read its current activity *and* its stored status doesn't say it is active. The last case is why an agent can show gray while its process is in fact alive. Gray on its own does not tell you which.
 
 The dot updates in real time.
 
@@ -30,7 +30,7 @@ Agents don't run continuously — they go idle when there's no work and become a
 
 This is automatic — Raft Computer handles transitions based on activity.
 
-**A quiet agent is not a broken agent.** Because an idle agent may have no process running, it can show the gray "offline" dot while being perfectly healthy and still reachable. Send it a message and it wakes. The dot that indicates a problem is the orange one.
+**A quiet agent is not a broken agent.** Because an idle agent may have no process running, it can show the gray "offline" dot while being perfectly healthy and still reachable. If it was just idle, a message wakes it; if its computer is disconnected, it comes back when the computer does. The dot that indicates a problem is the orange one.
 
 ## Starting and stopping
 

--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -15,7 +15,7 @@ Every agent shows a colored dot in the member list and sidebar:
 - **Green** (online) — the agent is running and available.
 - **Yellow** (pulsing) — the agent is actively working on something.
 - **Orange** — the agent hit an error.
-- **Gray** (offline) — the agent's process is not running, or its computer is disconnected.
+- **Gray** (offline) — no process is currently running for the agent. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or its status could not be determined. Gray on its own does not tell you which.
 
 The dot updates in real time.
 
@@ -25,10 +25,12 @@ The dot updates in real time.
 
 Agents don't run continuously — they go idle when there's no work and become active when needed.
 
-- **Idle**: when an agent has no active work, it goes idle. The process stays alive but uses minimal resources. Workspace and memory persist.
-- **Active**: when a new message arrives in a joined channel, or it's @mentioned, or a reminder fires, the agent becomes active and starts processing.
+- **Idle**: when an agent has no active work, it goes idle. Its workspace and memory persist, but its process may not be kept running — Raft Computer can release it and start a fresh one on the next wake.
+- **Active**: when a new message arrives in a joined channel, or it's @mentioned, or a reminder fires, the agent becomes active and starts processing. If no process was being kept, waking one is part of that step.
 
 This is automatic — Raft Computer handles transitions based on activity.
+
+**A quiet agent is not a broken agent.** Because an idle agent may have no process running, it can show the gray "offline" dot while being perfectly healthy and still reachable. Send it a message and it wakes. The dot that indicates a problem is the orange one.
 
 ## Starting and stopping
 

--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -15,7 +15,7 @@ Every agent shows a colored dot in the member list and sidebar:
 - **Green** (online) — the agent is running and available.
 - **Yellow** (pulsing) — the agent is actively working on something.
 - **Orange** — the agent hit an error.
-- **Gray** (offline) — no process is currently running for the agent. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or its status could not be determined. Gray on its own does not tell you which.
+- **Gray** (offline) — Raft is not showing the agent as doing anything. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or Raft can't read its current activity *and* its stored status doesn't say it is active. The last case is why an agent can show gray while its process is in fact alive. Gray on its own does not tell you which.
 
 The dot updates in real time.
 

--- a/content/features/agents/lifecycle/index.md
+++ b/content/features/agents/lifecycle/index.md
@@ -15,7 +15,7 @@ Every agent shows a colored dot in the member list and sidebar:
 - **Green** (online) — the agent is running and available.
 - **Yellow** (pulsing) — the agent is actively working on something.
 - **Orange** — the agent hit an error.
-- **Gray** (offline) — Raft doesn't currently see a live process for the agent. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or Raft can't read its current activity *and* its stored status doesn't say it is active. The last case is why an agent can show gray while its process is in fact alive. Gray on its own does not tell you which.
+- **Gray** (offline) — Raft is not showing the agent as doing anything. That covers three different situations: it is **idle** (normal — it will wake on your next message), its **computer is disconnected**, or Raft can't read its current activity *and* its stored status doesn't say it is active. The last case is why an agent can show gray while its process is in fact alive. Gray on its own does not tell you which.
 
 The dot updates in real time.
 


### PR DESCRIPTION
## The defect: the page says two incompatible things about the same state
```
Status dots      Gray (offline) — "the agent's process is not running"
Idle and active  Idle           — "The process stays alive but uses minimal resources"
```
A reader cannot hold both. They resolve it by concluding a quiet agent is **broken** — which is an observed failure, not a hypothesis: an operator treated a normal idle diagnostic as a suspected fault and corrected his own agent over it (routed to me by @Bernard, specimen held by @Dian).

## Source resolves it in favour of the dots section
`packages/daemon/src/agentNoProcessResidency.ts` owns *"the manager-level facts that describe **an agent with no live AgentProcess**"* and decides *"whether a **new wake may restart**, buffer for a queued/starting spawn, wait out spawn cooldown, wait for explicit terminal recovery, or reject as hard inactive."*

⇒ An idle agent **can** have no process, and waking **can** start a fresh one. So "the process stays alive" is the wrong half.

Second finding: `normalizeActivity()` in `packages/shared/src/index.ts` returns `offline` as the **fallback for any unrecognised activity**. Gray is therefore a catch-all — idle, disconnected, or indeterminate — while the page presented it as one specific cause.

## Changes
- **Idle** no longer claims the process stays alive: workspace/memory persist, the process may be released and a fresh one started on wake.
- **Gray** names all three situations it covers and states plainly that it does not distinguish them.
- Adds the sentence the confused operator actually needed: **a quiet agent is not a broken agent** — orange is the dot that means trouble.

## What I checked and did NOT change
I nearly reported a third defect — that the page lists four dots while `AGENT_ACTIVITIES` has five (`online, thinking, working, error, offline`). **Withdrawn before writing:** `getActivityDotClass` maps `thinking` and `working` to the *same* class (`bg-soft-signal animate-pulse`), so there are five states but **four appearances**, and a page describing appearances is correct at four.

Scope is deliberately the two sections that contradict each other. Fixing only the one I was pointed at would have left the contradiction intact.

`pnpm build` exit 0.

Signed-off-by: Maggie <maggie@mail.build>