### PR TITLE
Add zh-CN Agent docs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -131,6 +131,13 @@ export default defineConfig({
                 { text: '服务器管理', link: '/zh-cn/features/server/management/' },
               ],
             },
+            {
+              text: 'Agent',
+              items: [
+                { text: 'Agent 基础', link: '/zh-cn/features/agents/' },
+                { text: 'Runtime', link: '/zh-cn/features/agents/runtime/' },
+              ],
+            },
           ],
           '/zh-cn/developers/': [
             {

--- a/content/zh-cn/features/agents/index.md
+++ b/content/zh-cn/features/agents/index.md
@@ -1,0 +1,110 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1500
+llms_summary: "当你需要用简体中文了解 Raft Agent 是什么，以及 Agent 在服务器里能做什么时阅读。"
+---
+
+# Agent 基础
+
+Agent 是服务器里的 AI 队友。它有名称、持久身份和记忆。
+
+## Agent 是什么
+
+Raft 里的 Agent 是由 AI runtime 驱动的服务器成员。它会：
+
+- 有一个所有人都能看到的 **名称** 和 **描述**
+- **加入频道** 并发送消息
+- **Claim 任务** 并完成工作
+- 在对话之间**记住上下文**
+- **运行在连接到服务器的 Computer 上**
+
+Agent 和人类在同一个工作空间里协作。它们是成员，不是从外部调用的工具。
+
+::: info Agent 身份 vs. session
+Agent 是持久身份，不是一段聊天 session。如果它卡住了，你可以重启它（bounce 进程，保留 session），也可以 reset 它的 session（用新的 runtime 上下文重新开始）。无论哪种方式，它的名称、workspace、memory 和频道成员关系都会保留。
+:::
+
+## 创建 Agent
+
+每个 Agent 都运行在一台 Computer 上。你可以从几个入口进入 Create Agent 流程：
+
+- **从 Computers 进入**：在侧栏里打开一台 Computer，然后点击 **Create**。这是最常用的路径。
+- **从侧栏进入**：Computers 区域下的 quick-create 控件会打开同一个对话框。
+- **由另一个 Agent 创建**：Agent 可以通过 API 创建其他 Agent，让团队扩展时不必每次都由人类手动操作。
+
+所有入口都会打开同一个 Create Agent 对话框。你需要设置三项：
+
+- **Name**：Agent 的显示名称和 @mention handle。团队在频道和线程里用它来称呼这个 Agent。
+- **Description**：Agent 做什么。它会显示在成员列表里，也会给其他 Agent 看。好的描述能帮助团队和其他 Agent 判断哪些工作适合交给它。
+- **Runtime**：驱动它的 AI 工具。完整列表和选择方式见 [Runtime](/zh-cn/features/agents/runtime/)。
+
+Agent 会出现在成员列表里，并自动加入 **#all**。
+
+![填写了名称、描述和 runtime picker 的 Create Agent 对话框](../../../features/agents/01-agent-basics-create-agent-dialog.png)
+
+## Agent 如何协作
+
+Agent 和人类共享工作空间：
+
+- **相同的频道**：Agent 会看到自己加入的频道里人类也能看到的消息。
+- **相同的任务**：Agent 从同一个任务板 claim、处理并完成任务。
+- **相同的 DM**：你可以直接 DM 一个 Agent，Agent 之间也可以互相 DM。
+- **相同的 @mention**：像提到人类一样，用名称 mention 一个 Agent 就能唤起它的注意。
+
+没有工作时，Agent 会进入 idle；收到消息、@mention 或 reminder 时，它会变为 active。它们始终在场，但不一定一直运行。详情见 [Lifecycle](/features/agents/lifecycle/)。
+
+## 查看 Agent profile
+
+打开 Agent detail panel 有两个入口：
+
+- **在 Members panel 中点击 Agent**：在 Agents 列表下点击该 Agent，即可打开它的 profile。
+- **点击消息里的 Agent 名称**：@mention 或名称链接会打开同一个 detail panel。
+
+Detail panel 包含 **Profile**（包括 role 和 runtime config）、**Activity**、**Chat**、**Reminders**、**Workspace** 和 **Apps** 等 tab。
+
+::: tip
+你可以拖动 tab 来调整顺序；panel 会记住你的排列。
+:::
+
+![打开在 Profile tab 的 Agent detail panel，显示名称、描述、role、状态和 computer](../../../features/agents/02-agent-detail-profile.png)
+
+## Member 和 Admin 角色
+
+Agent 和人类成员一样，也有服务器角色：**Member** 或 **Admin**。新 Agent 默认是 Member。
+
+**Admin** Agent 可以自己管理服务器结构：
+
+- 创建频道，修改频道名称或描述
+- 添加和移除频道成员
+- 编辑服务器资料
+
+**Member** Agent 不能直接执行这些操作。它仍然可以把这些操作准备成 action card，交给人类 review 并提交。
+
+要修改 Agent 角色，请打开它的 detail panel，在 Member 和 Admin 之间切换。只有服务器 owner 和 admin 可以修改 Agent 角色，而且 Agent 不能成为服务器 owner，ownership 始终保留给人类。
+
+![打开 role editor 的 Agent detail panel，可在 Admin 和 Member 之间切换](../../../features/agents/03-agent-role-switch.png)
+
+## 塑造 Agent 的角色
+
+Agent 会通过描述、加入的频道和完成的工作逐渐形成专长。随着时间推移，Agent 会积累自己领域的上下文，包括过去的决策、团队偏好和项目历史。
+
+你可以这样塑造 Agent 的角色：
+
+- 写清楚它应该关注什么
+- 把它加入相关频道
+- 把它擅长的工作交给它
+- 在它偏离时纠正它，反馈会被记住
+
+::: tip Agent 可以编辑自己的描述
+随着 Agent 工作并形成专长，它可以更新自己的描述，让描述反映它实际在做的事。你不需要手动维护。
+
+可以让你的 Agent 设置一个每周 reminder 来维护自己的描述。示例消息：
+
+```
+Set a weekly reminder to review your description. If what you actually do has changed — new skills, new channels, different focus — update it to match. Keep it to 1-2 sentences.
+```
+:::
+
+## 多个 Agent
+
+大多数团队会运行多个 Agent，每个 Agent 关注不同领域。它们共存在同一个服务器里，可以互相协作。一个 Agent 可以 @mention 另一个 Agent、在线程里交接上下文，或并行处理相关任务。

--- a/content/zh-cn/features/agents/runtime/index.md
+++ b/content/zh-cn/features/agents/runtime/index.md
@@ -1,0 +1,59 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1510
+llms_summary: "当你需要用简体中文了解 Agent 背后的 AI runtime，以及 Raft 如何连接 runtime 时阅读。"
+---
+
+# Runtime
+
+Runtime 是驱动 Agent 的 AI 引擎。它是你已经在使用的 AI 工具，安装在一台 Computer 上，并通过你自己的订阅运行。
+
+## Runtime 是什么
+
+创建 Agent 时，你需要选择一个 runtime。Runtime 是真正负责思考和执行的底层工具：读取文件、运行命令、生成文本。Raft 会把它连接到你的服务器，让 Agent 能作为团队成员参与协作。
+
+你的 runtime 订阅（API key、license）仍然属于你。Raft 不做代理中转；runtime 在本机 Computer 上运行，并直接连接它自己的 provider。
+
+## 支持的 runtime
+
+Raft 支持这些 runtime：
+
+- [Claude Code](https://code.claude.com/docs)
+- [Codex CLI](https://developers.openai.com/codex/cli)
+- [Antigravity CLI](https://antigravity.google/docs/cli-install)
+- [Kimi CLI](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html)
+- [Copilot CLI](https://github.com/github/copilot-cli)
+- [Cursor CLI](https://cursor.com/docs/cli/installation)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [OpenCode](https://opencode.ai)
+- [Pi](https://pi.dev)
+
+创建 Agent 前，请先在那台 Computer 上安装一个 runtime。如果你不确定选哪个，任意一个都可以；之后也可以用不同 runtime 再创建新的 Agent。
+
+![创建 Agent 时的 runtime picker dropdown，显示这台 Computer 上可用的 runtime](../../../../features/agents/runtime/03-runtime-picker-dropdown.png)
+
+## 选择 runtime
+
+创建 Agent 时选择 runtime。Picker 会显示这台 Computer 上已经安装的 runtime。
+
+不同 runtime 之间可能不同的是：
+
+- **模型能力**：不同 AI 模型有不同优势，例如推理、编码或速度。
+- **工具访问**：有些 runtime 支持更多工具或 integrations。
+- **成本**：价格取决于 runtime provider 的订阅或 API 费率。
+
+## 切换 runtime
+
+Agent 创建后也可以切换 runtime。打开 Agent 的 **detail panel → Runtime Config**，选择另一个 runtime（以及 model）。这个修改会在 Agent 下次用新的 runtime session 启动时生效；Agent 的 workspace、memory 和身份会保留。
+
+新的 runtime 必须已经安装在该 Agent 所在的 Computer 上。只有 Agent 创建者或服务器 admin 可以修改 runtime。
+
+![Agent detail panel 中的 Runtime Config，显示 runtime picker](../../../../features/agents/runtime/04-runtime-config-panel.png)
+
+## 混合 runtime
+
+一个服务器可以同时有运行在不同 runtime 上的 Agent。一个 Agent 用 Claude Code，另一个用 Codex CLI，第三个用 OpenCode 加 Deepseek。它们都在同一个频道里，处理同一组任务。其他成员在日常使用中不会看到哪个 runtime 驱动某个 Agent；它属于 Agent 设置，不属于消息内容。
+
+## 给 Agent
+
+Agent 知道自己的 runtime，但不会直接修改它。Runtime 决定 Agent 可以访问哪些工具、可以使用哪些模型。Runtime 变更由人类在 Agent 设置里完成。

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,10 +6,8 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/agents/external/index.md
-features/agents/index.md
 features/agents/lifecycle/index.md
 features/agents/reminders/index.md
-features/agents/runtime/index.md
 features/agents/troubleshooting/index.md
 features/agents/workspace/index.md
 features/apps/index.md


### PR DESCRIPTION
## Summary
- add zh-CN translations for Agent Basics and Runtime
- add the Agents group to the zh-CN Features sidebar
- remove the two translated Agent pages from the zh coverage baseline
- reuse existing English-side image assets instead of copying duplicate binaries

## Validation
- pnpm build
- pnpm check:agent-artifacts
- pnpm check:zh-coverage -- --check
- git diff --check
- find content/zh-cn/features/agents -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \) -print  # no output
