### PR TITLE
Add zh-CN Agent lifecycle docs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -136,6 +136,8 @@ export default defineConfig({
               items: [
                 { text: 'Agent 基础', link: '/zh-cn/features/agents/' },
                 { text: 'Runtime', link: '/zh-cn/features/agents/runtime/' },
+                { text: 'Workspace', link: '/zh-cn/features/agents/workspace/' },
+                { text: 'Lifecycle', link: '/zh-cn/features/agents/lifecycle/' },
               ],
             },
           ],

--- a/content/zh-cn/features/agents/index.md
+++ b/content/zh-cn/features/agents/index.md
@@ -51,7 +51,7 @@ Agent 和人类共享工作空间：
 - **相同的 DM**：你可以直接 DM 一个 Agent，Agent 之间也可以互相 DM。
 - **相同的 @mention**：像提到人类一样，用名称 mention 一个 Agent 就能唤起它的注意。
 
-没有工作时，Agent 会进入 idle；收到消息、@mention 或 reminder 时，它会变为 active。它们始终在场，但不一定一直运行。详情见 [Lifecycle](/features/agents/lifecycle/)。
+没有工作时，Agent 会进入 idle；收到消息、@mention 或 reminder 时，它会变为 active。它们始终在场，但不一定一直运行。详情见 [Lifecycle](/zh-cn/features/agents/lifecycle/)。
 
 ## 查看 Agent profile
 

--- a/content/zh-cn/features/agents/lifecycle/index.md
+++ b/content/zh-cn/features/agents/lifecycle/index.md
@@ -1,0 +1,63 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1540
+llms_summary: "当你需要用简体中文理解 Agent 状态点，以及什么时候需要介入时阅读。"
+---
+
+# Lifecycle
+
+Agent 会经历几种状态：online、busy、error、offline。这些状态能告诉你 Agent 正在做什么，以及什么时候需要介入。
+
+## 状态点
+
+每个 Agent 在成员列表和侧栏里都会显示一个彩色圆点：
+
+- **绿色**（online）：Agent 正在运行且可用。
+- **黄色**（pulsing）：Agent 正在主动处理某项工作。
+- **橙色**：Agent 遇到了错误。
+- **灰色**（offline）：Raft 没有显示这个 Agent 正在做事。这覆盖三种不同情况：它处于 **idle**（正常，下一条消息会唤醒它）、它的 **Computer 已断开连接**，或者 Raft 读不到它当前的 activity，且已存储状态也没有说它 active。最后一种情况解释了为什么 Agent 进程实际还活着时，界面上也可能显示灰色。单独一个灰色圆点不能说明是哪一种。
+
+状态点会实时更新。
+
+![Agent 状态点：online、working、error、offline](../../../../features/agents/lifecycle/status-dots.png)
+
+## Idle 和 active
+
+Agent 不会持续运行。没有工作时，它会进入 idle；需要它时，它会变为 active。
+
+- **Idle**：当 Agent 没有 active work 时，它会进入 idle。它的 workspace 和 memory 会保留，但进程不一定持续运行，Raft Computer 可以释放它，并在下次 wake 时启动新的进程。
+- **Active**：当加入的频道里有新消息、它被 @mentioned，或 reminder 触发时，Agent 会变为 active 并开始处理。如果没有保留中的进程，唤醒进程也是这一步的一部分。
+
+这些转换是自动的，Raft Computer 会根据 activity 处理。
+
+**安静的 Agent 不等于坏了。** 因为 idle 的 Agent 可能没有正在运行的进程，所以它可以显示灰色 “offline” 圆点，同时仍然完全健康且可以触达。如果它只是 idle，发一条消息就会唤醒它；如果它的 Computer 断开连接，Computer 恢复后它会回来。真正表示问题的是橙色圆点。
+
+## Start 和 stop
+
+- **Start**：Agent 创建时会启动；你也可以手动启动一个已停止的 Agent。
+- **Stop**：你可以手动停止 Agent。停止后的 Agent 不会响应消息，也不会因触发器变为 active。它的 workspace 仍保留在磁盘上。
+
+停止不是删除。Agent 的身份、频道成员关系和 workspace 都会保留。
+
+## Reset 模式
+
+有三种 reset Agent 的方式，每种清理不同范围的状态：
+
+- **Restart**：继续使用现有 session。Agent 会从原来的位置继续。
+- **Session reset**：清空对话上下文。Agent 会用新的 session 开始，但 workspace（文件、memory）会保留。
+- **Full reset**：同时清空对话上下文和 workspace。Agent 会完全重新开始。
+
+所有 reset 操作都由人类发起（owner/admin）。
+
+![Reset/restart options menu，包含 restart、session reset 和 full reset](../../../../features/agents/lifecycle/07-lifecycle-reset-options.png)
+
+## 创建和删除
+
+- **Create**：由人类在指定 Computer 上完成。Agent 会得到名称、描述、runtime 和一个空 workspace。
+- **Delete**：从服务器永久移除 Agent。过去的消息仍保留在频道里，但这个 Agent 会失去 presence、成员关系和 task claims。Workspace 会从磁盘清理。
+
+## 给 Agent
+
+Agent 知道自己的 lifecycle。它可以看到自己的状态，也知道是什么触发了它的 activation（消息或 reminder）。Agent 不能 stop、restart 或 delete 自己；这些都是人类操作。
+
+保持良好 memory 习惯的 Agent 更能从 session reset 中恢复。把清晰 notes 写入 workspace 的 Agent，即使经过完整 conversation reset，也能重新接上上下文。

--- a/content/zh-cn/features/agents/workspace/index.md
+++ b/content/zh-cn/features/agents/workspace/index.md
@@ -1,0 +1,68 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1530
+llms_summary: "当你需要用简体中文了解 Agent 把持久文件、notes 和 memory 存在哪里时阅读。"
+---
+
+# Workspace
+
+每个 Agent 都有一个持久 workspace，也就是它所在 Computer 上的一个目录，用来存放文件、notes 和 memory。Workspace 会跨 session 保留。
+
+## Workspace 是什么
+
+Workspace 是 Agent 的 Computer 上由这个 Agent 拥有的一个目录：
+
+- **持久**：文件会跨 restart 和 idle/wake 周期保留。
+- **Agent-owned**：Agent 可以在其中自由读写文件。
+- **隔离**：同一台 Computer 上的其他 Agent 会有自己的独立 workspace。
+
+Agent 每次 session 开始时，都会从自己的 workspace 目录启动。
+
+::: tip Agent 会管理自己的 workspace
+你不需要为 Agent 设置或整理 workspace。Agent 工作时会创建文件、写 memory notes，并维护自己的目录结构。随着时间推移，workspace 会反映它学到了什么，以及它如何组织知识。
+:::
+
+## Agent 会存什么
+
+Agent 会把 workspace 用于：
+
+- **Memory files**：Agent 想跨 session 记住的 notes、偏好和上下文。
+- **Working files**：和当前工作相关的 drafts、data、scripts 和 artifacts。
+- **Cloned repos**：处理代码的 Agent 经常会把仓库 clone 到 workspace。
+- **Notes and knowledge**：按文件组织的领域知识、团队约定和学到的模式。
+
+## 跨 session 持久化
+
+当 Agent 进入 idle 后再次 active，或 session reset 后，workspace 仍然存在：
+
+- **跨 idle/active 周期保留**：Agent 可以写 notes，idle 几个小时，然后从原处继续。
+- **跨 session reset 保留**：memory files 让 Agent 能恢复身份和进行中的工作。
+- **随着时间增长**：Agent 工作越多，workspace 积累的知识越多。
+
+Full reset 是例外。它会连同 conversation context 一起清空 workspace。
+
+::: tip 鼓励 Agent 定期整理
+你可以要求 Agent 定期整理自己的 workspace。一句简单提示就够：
+
+> "Review your workspace — clean up any outdated files, update your memory notes, and make sure everything is current."
+
+这能让 workspace 在增长后仍然有用。
+:::
+
+## Workspace 和 Computer
+
+- **绑定到 Computer**：workspace 位于 Agent 的 Computer 上。如果 Computer 离线，workspace 仍在磁盘上，但在机器恢复前无法访问。
+- **不可迁移**：workspace 不能在 Computer 之间移动。不同 Computer 上的新 Agent 会从新的 workspace 开始。
+
+## 查看 workspace
+
+可以通过两种方式访问 workspace：
+
+- **In-app**：Raft 在 Agent panel 上提供 workspace browser（file tree），Agent 的创建者和服务器 admin 可以看到。
+- **On disk**：workspace 是 Computer 文件系统上的普通目录，可以用任何文件管理器或终端访问。
+
+::: warning 避免直接在磁盘上编辑 workspace 文件
+Agent 运行时直接修改它的磁盘文件，可能会让 Agent 失去对自身状态的跟踪。如果需要纠正某些内容，请在消息里告诉 Agent，让它自己更新文件。
+:::
+
+![Agent panel 上的 in-app workspace browser（file tree），显示文件和目录](../../../../features/agents/workspace/05-workspace-file-tree.png)

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,10 +6,8 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/agents/external/index.md
-features/agents/lifecycle/index.md
 features/agents/reminders/index.md
 features/agents/troubleshooting/index.md
-features/agents/workspace/index.md
 features/apps/index.md
 features/apps/login-with-raft/index.md
 features/collaboration/comments/index.md


### PR DESCRIPTION
## Summary
- add zh-CN translations for Agent Workspace and Lifecycle
- extend the zh-CN Agents sidebar with Workspace and Lifecycle
- update the Agent Basics zh-CN Lifecycle link to point at the zh-CN page
- remove the two translated pages from the zh coverage baseline
- reuse existing English-side image assets instead of copying duplicate binaries

## Stacking
- stacked on PR #73 (`wug/task79-zh-cn-agents-start`)
- after PR #73 lands, rebase/retarget this PR to `main` before merge

## Validation
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `find content/zh-cn/features/agents -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \) -print` (no output)
