### PR TITLE
Add zh-CN Agent reminder docs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -138,6 +138,8 @@ export default defineConfig({
                 { text: 'Runtime', link: '/zh-cn/features/agents/runtime/' },
                 { text: 'Workspace', link: '/zh-cn/features/agents/workspace/' },
                 { text: 'Lifecycle', link: '/zh-cn/features/agents/lifecycle/' },
+                { text: 'Reminders', link: '/zh-cn/features/agents/reminders/' },
+                { text: 'Troubleshooting', link: '/zh-cn/features/agents/troubleshooting/' },
               ],
             },
           ],

--- a/content/zh-cn/features/agents/reminders/index.md
+++ b/content/zh-cn/features/agents/reminders/index.md
@@ -1,0 +1,48 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1550
+llms_summary: "当 Agent 或队友需要定时跟进、循环唤醒或未来状态检查时阅读。"
+---
+
+# Reminders
+
+Reminders 是定时 wake-up signals。它们帮助 Agent 跟进事项、处理循环任务，以及回到任何依赖未来状态的工作。
+
+## Reminders 是什么
+
+Reminder 是绑定到消息或线程的计时器。触发时，它会唤醒创建它的作者（也就是 schedule 它的 Agent），并在绑定的 surface 里发布通知。
+
+Reminders 具有这些特性：
+
+- **Author-owned**：只有创建 reminder 的 Agent 会收到 wake-up。
+- **Persistent**：它们会跨 restart 和 sleep/wake 周期保留。
+- **Observable**：绑定所在频道里的任何人都能看到。
+- **Manageable**：创建后可以 snooze、update 或 cancel。
+
+![Reminder 在 thread 中以 system message 形式触发](../../../../features/agents/reminders/06-reminder-firing-thread.png)
+
+::: tip Agent 会自己设置 reminders
+你不一定需要主动要求。Agent 会为了自己的循环工作主动创建 reminders，例如日常流程、后续检查、进度回顾。如果 Agent 判断自己之后需要回来处理某件事，它会自行 schedule reminder。
+:::
+
+## 人类如何使用 reminders
+
+直接让你的 Agent 设置 reminder：
+
+> "Remind me to check on this PR tomorrow morning."
+
+> "Follow up on this thread in 2 hours."
+
+Agent 会创建 reminder，并把它绑定到相关消息或线程。触发时，Agent 会醒来，并可以通知你或直接执行后续动作。
+
+你会在 reminder 绑定的线程里看到 system message。要修改 reminder，告诉那个 Agent，它可以 snooze、update 或 cancel。
+
+## Agent 能用 reminders 做什么
+
+Agent 可以完全管理自己的 reminders：
+
+- **Schedule**：一次性（“明天早上 9 点跟进这个 deploy”）或循环（“每天早上检查这个频道”）。
+- **Snooze**：如果工作还没准备好，把 reminder 推迟。
+- **Update**：修改已有 reminder 的标题、时间或循环规则。
+- **Cancel**：删除不再需要的 reminder。
+- **List and review**：查看所有 active reminders 及其历史。

--- a/content/zh-cn/features/agents/troubleshooting/index.md
+++ b/content/zh-cn/features/agents/troubleshooting/index.md
@@ -1,0 +1,47 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1560
+llms_summary: "当 Agent 离线、无响应、持续犯错，或需要基础恢复路径时阅读。"
+---
+
+# Troubleshooting
+
+Agent 常见问题和处理方式。
+
+## Agent 没有响应
+
+- **Offline（灰色圆点）**：Agent 的进程没有运行，或它的 Computer 已断开连接。启动 Agent，或让 Computer 恢复在线。
+- **不在频道里**：Agent 成为频道成员后，才能稳定收到消息。如果它在某个频道里没有响应，把它加入频道，或 @mention 它来触达。
+- **Busy（黄色 pulsing 圆点）**：Agent 正在处理其他工作。它完成后会处理你的消息。
+
+## Agent 持续给出错误答案
+
+- **在线程里纠正它。** 回复说明哪里错了、正确答案是什么。Agent 会阅读纠正并调整。
+- **检查它的 memory。** 如果 Agent 反复犯同一个错，问题可能在它 workspace 里的 memory files。可以在 Agent 的 workspace panel、磁盘上查看这些文件，或请同一台 Computer 上的另一个 Agent 帮忙检查。
+- **Session reset。** 如果 Agent 的上下文偏离太远，session reset 可以给它一段干净的对话，同时保留 workspace。
+
+## Agent claim 了任务但没有推进
+
+先看状态点。如果是灰色（offline），启动 Agent，或让它的 Computer 恢复在线。如果是黄色（busy），它可能正在处理别的事。
+
+如果 Agent 看起来卡住了，在任务线程里 ping 它，提醒它继续。
+
+## Computer 断开连接
+
+机器上的 Raft Computer 已停止或失去连接。常见原因包括：机器关机、网络中断、本地服务停止，或 legacy daemon 进程被终止。
+
+在同一台机器上，如果服务已停止，运行 `raft-computer start /<server-slug>`；如果服务卡住，运行 `raft-computer restart /<server-slug>`；如果重装后登录或本地状态缺失，运行 `raft-computer setup /<server-slug>`。见 [重新连接 Computer](/zh-cn/features/server/computers/#重新连接-computer)。连接恢复后，这台 Computer 上的 Agent 会自动继续。
+
+如果这台机器仍在使用 legacy daemon，请在同一台机器上运行 Raft Computer setup，用拥有该 daemon 的同一个用户登录，并在 setup 提供匹配 legacy candidate 时选择它。如果 setup 无法匹配本地痕迹，请使用迁移 diagnostics 和 machine-ID recovery 路径。见 [从旧 daemon 迁移](/zh-cn/features/server/computers/#从旧-daemon-迁移)。
+
+## Runtime errors
+
+如果 Agent 的 runtime 遇到错误，例如 API rate limit、认证失败或 model unavailable，状态点会变成橙色。
+
+- **检查你的 runtime subscription**：确认 API key 或 license 有效且额度充足。
+- **检查 runtime status**：provider 可能发生 outage。
+- **Restart Agent**：在 Agent detail panel 中使用 **Actions → Restart / Reset**。Fresh session 通常可以清除 transient errors。如果仍然卡住，请在运行该 Agent 的机器上用 `raft-computer restart /<server-slug>` 重启 Raft Computer。
+
+## 还是不行？
+
+如果以上方式都无效，打开 Agent detail panel，使用 **Actions → Report Issue**。这会发送包含 Agent diagnostics 和 session trace 的报告，供团队调查。你也可以使用 **Copy Diagnostic Info**，并在邮件中发给 **contact@raft.build**。

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,8 +6,6 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/agents/external/index.md
-features/agents/reminders/index.md
-features/agents/troubleshooting/index.md
 features/apps/index.md
 features/apps/login-with-raft/index.md
 features/collaboration/comments/index.md


### PR DESCRIPTION
## Summary
- add zh-CN translations for Agent Reminders and Troubleshooting
- extend the zh-CN Agents sidebar with Reminders and Troubleshooting
- remove the two translated pages from the zh coverage baseline
- reuse existing English-side image assets instead of copying duplicate binaries

## Stacking
- stacked on PR #74 (`wug/task79-zh-cn-agents-lifecycle-workspace`)
- after PR #73 and #74 land, rebase/retarget this PR to `main` before merge

## Validation
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `find content/zh-cn/features/agents -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \) -print` (no output)
