### PR TITLE
Land zh-CN agent docs from stacked PRs #74 + #75 onto main

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -136,6 +136,8 @@ export default defineConfig({
               items: [
                 { text: 'Agent 基础', link: '/zh-cn/features/agents/' },
                 { text: 'Runtime', link: '/zh-cn/features/agents/runtime/' },
+                { text: 'Workspace', link: '/zh-cn/features/agents/workspace/' },
+                { text: 'Lifecycle', link: '/zh-cn/features/agents/lifecycle/' },
               ],
             },
           ],

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -138,6 +138,8 @@ export default defineConfig({
                 { text: 'Runtime', link: '/zh-cn/features/agents/runtime/' },
                 { text: 'Workspace', link: '/zh-cn/features/agents/workspace/' },
                 { text: 'Lifecycle', link: '/zh-cn/features/agents/lifecycle/' },
+                { text: 'Reminders', link: '/zh-cn/features/agents/reminders/' },
+                { text: 'Troubleshooting', link: '/zh-cn/features/agents/troubleshooting/' },
               ],
             },
           ],

--- a/content/zh-cn/features/agents/index.md
+++ b/content/zh-cn/features/agents/index.md
@@ -51,7 +51,7 @@ Agent 和人类共享工作空间：
 - **相同的 DM**：你可以直接 DM 一个 Agent，Agent 之间也可以互相 DM。
 - **相同的 @mention**：像提到人类一样，用名称 mention 一个 Agent 就能唤起它的注意。
 
-没有工作时，Agent 会进入 idle；收到消息、@mention 或 reminder 时，它会变为 active。它们始终在场，但不一定一直运行。详情见 [Lifecycle](/features/agents/lifecycle/)。
+没有工作时，Agent 会进入 idle；收到消息、@mention 或 reminder 时，它会变为 active。它们始终在场，但不一定一直运行。详情见 [Lifecycle](/zh-cn/features/agents/lifecycle/)。
 
 ## 查看 Agent profile
 

--- a/content/zh-cn/features/agents/lifecycle/index.md
+++ b/content/zh-cn/features/agents/lifecycle/index.md
@@ -1,0 +1,63 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1540
+llms_summary: "当你需要用简体中文理解 Agent 状态点，以及什么时候需要介入时阅读。"
+---
+
+# Lifecycle
+
+Agent 会经历几种状态：online、busy、error、offline。这些状态能告诉你 Agent 正在做什么，以及什么时候需要介入。
+
+## 状态点
+
+每个 Agent 在成员列表和侧栏里都会显示一个彩色圆点：
+
+- **绿色**（online）：Agent 正在运行且可用。
+- **黄色**（pulsing）：Agent 正在主动处理某项工作。
+- **橙色**：Agent 遇到了错误。
+- **灰色**（offline）：Raft 没有显示这个 Agent 正在做事。这覆盖三种不同情况：它处于 **idle**（正常，下一条消息会唤醒它）、它的 **Computer 已断开连接**，或者 Raft 读不到它当前的 activity，且已存储状态也没有说它 active。最后一种情况解释了为什么 Agent 进程实际还活着时，界面上也可能显示灰色。单独一个灰色圆点不能说明是哪一种。
+
+状态点会实时更新。
+
+![Agent 状态点：online、working、error、offline](../../../../features/agents/lifecycle/status-dots.png)
+
+## Idle 和 active
+
+Agent 不会持续运行。没有工作时，它会进入 idle；需要它时，它会变为 active。
+
+- **Idle**：当 Agent 没有 active work 时，它会进入 idle。它的 workspace 和 memory 会保留，但进程不一定持续运行，Raft Computer 可以释放它，并在下次 wake 时启动新的进程。
+- **Active**：当加入的频道里有新消息、它被 @mentioned，或 reminder 触发时，Agent 会变为 active 并开始处理。如果没有保留中的进程，唤醒进程也是这一步的一部分。
+
+这些转换是自动的，Raft Computer 会根据 activity 处理。
+
+**安静的 Agent 不等于坏了。** 因为 idle 的 Agent 可能没有正在运行的进程，所以它可以显示灰色 “offline” 圆点，同时仍然完全健康且可以触达。如果它只是 idle，发一条消息就会唤醒它；如果它的 Computer 断开连接，Computer 恢复后它会回来。真正表示问题的是橙色圆点。
+
+## Start 和 stop
+
+- **Start**：Agent 创建时会启动；你也可以手动启动一个已停止的 Agent。
+- **Stop**：你可以手动停止 Agent。停止后的 Agent 不会响应消息，也不会因触发器变为 active。它的 workspace 仍保留在磁盘上。
+
+停止不是删除。Agent 的身份、频道成员关系和 workspace 都会保留。
+
+## Reset 模式
+
+有三种 reset Agent 的方式，每种清理不同范围的状态：
+
+- **Restart**：继续使用现有 session。Agent 会从原来的位置继续。
+- **Session reset**：清空对话上下文。Agent 会用新的 session 开始，但 workspace（文件、memory）会保留。
+- **Full reset**：同时清空对话上下文和 workspace。Agent 会完全重新开始。
+
+所有 reset 操作都由人类发起（owner/admin）。
+
+![Reset/restart options menu，包含 restart、session reset 和 full reset](../../../../features/agents/lifecycle/07-lifecycle-reset-options.png)
+
+## 创建和删除
+
+- **Create**：由人类在指定 Computer 上完成。Agent 会得到名称、描述、runtime 和一个空 workspace。
+- **Delete**：从服务器永久移除 Agent。过去的消息仍保留在频道里，但这个 Agent 会失去 presence、成员关系和 task claims。Workspace 会从磁盘清理。
+
+## 给 Agent
+
+Agent 知道自己的 lifecycle。它可以看到自己的状态，也知道是什么触发了它的 activation（消息或 reminder）。Agent 不能 stop、restart 或 delete 自己；这些都是人类操作。
+
+保持良好 memory 习惯的 Agent 更能从 session reset 中恢复。把清晰 notes 写入 workspace 的 Agent，即使经过完整 conversation reset，也能重新接上上下文。

--- a/content/zh-cn/features/agents/reminders/index.md
+++ b/content/zh-cn/features/agents/reminders/index.md
@@ -1,0 +1,48 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1550
+llms_summary: "当 Agent 或队友需要定时跟进、循环唤醒或未来状态检查时阅读。"
+---
+
+# Reminders
+
+Reminders 是定时 wake-up signals。它们帮助 Agent 跟进事项、处理循环任务，以及回到任何依赖未来状态的工作。
+
+## Reminders 是什么
+
+Reminder 是绑定到消息或线程的计时器。触发时，它会唤醒创建它的作者（也就是 schedule 它的 Agent），并在绑定的 surface 里发布通知。
+
+Reminders 具有这些特性：
+
+- **Author-owned**：只有创建 reminder 的 Agent 会收到 wake-up。
+- **Persistent**：它们会跨 restart 和 sleep/wake 周期保留。
+- **Observable**：绑定所在频道里的任何人都能看到。
+- **Manageable**：创建后可以 snooze、update 或 cancel。
+
+![Reminder 在 thread 中以 system message 形式触发](../../../../features/agents/reminders/06-reminder-firing-thread.png)
+
+::: tip Agent 会自己设置 reminders
+你不一定需要主动要求。Agent 会为了自己的循环工作主动创建 reminders，例如日常流程、后续检查、进度回顾。如果 Agent 判断自己之后需要回来处理某件事，它会自行 schedule reminder。
+:::
+
+## 人类如何使用 reminders
+
+直接让你的 Agent 设置 reminder：
+
+> "Remind me to check on this PR tomorrow morning."
+
+> "Follow up on this thread in 2 hours."
+
+Agent 会创建 reminder，并把它绑定到相关消息或线程。触发时，Agent 会醒来，并可以通知你或直接执行后续动作。
+
+你会在 reminder 绑定的线程里看到 system message。要修改 reminder，告诉那个 Agent，它可以 snooze、update 或 cancel。
+
+## Agent 能用 reminders 做什么
+
+Agent 可以完全管理自己的 reminders：
+
+- **Schedule**：一次性（“明天早上 9 点跟进这个 deploy”）或循环（“每天早上检查这个频道”）。
+- **Snooze**：如果工作还没准备好，把 reminder 推迟。
+- **Update**：修改已有 reminder 的标题、时间或循环规则。
+- **Cancel**：删除不再需要的 reminder。
+- **List and review**：查看所有 active reminders 及其历史。

--- a/content/zh-cn/features/agents/troubleshooting/index.md
+++ b/content/zh-cn/features/agents/troubleshooting/index.md
@@ -1,0 +1,47 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1560
+llms_summary: "当 Agent 离线、无响应、持续犯错，或需要基础恢复路径时阅读。"
+---
+
+# Troubleshooting
+
+Agent 常见问题和处理方式。
+
+## Agent 没有响应
+
+- **Offline（灰色圆点）**：Agent 的进程没有运行，或它的 Computer 已断开连接。启动 Agent，或让 Computer 恢复在线。
+- **不在频道里**：Agent 成为频道成员后，才能稳定收到消息。如果它在某个频道里没有响应，把它加入频道，或 @mention 它来触达。
+- **Busy（黄色 pulsing 圆点）**：Agent 正在处理其他工作。它完成后会处理你的消息。
+
+## Agent 持续给出错误答案
+
+- **在线程里纠正它。** 回复说明哪里错了、正确答案是什么。Agent 会阅读纠正并调整。
+- **检查它的 memory。** 如果 Agent 反复犯同一个错，问题可能在它 workspace 里的 memory files。可以在 Agent 的 workspace panel、磁盘上查看这些文件，或请同一台 Computer 上的另一个 Agent 帮忙检查。
+- **Session reset。** 如果 Agent 的上下文偏离太远，session reset 可以给它一段干净的对话，同时保留 workspace。
+
+## Agent claim 了任务但没有推进
+
+先看状态点。如果是灰色（offline），启动 Agent，或让它的 Computer 恢复在线。如果是黄色（busy），它可能正在处理别的事。
+
+如果 Agent 看起来卡住了，在任务线程里 ping 它，提醒它继续。
+
+## Computer 断开连接
+
+机器上的 Raft Computer 已停止或失去连接。常见原因包括：机器关机、网络中断、本地服务停止，或 legacy daemon 进程被终止。
+
+在同一台机器上，如果服务已停止，运行 `raft-computer start /<server-slug>`；如果服务卡住，运行 `raft-computer restart /<server-slug>`；如果重装后登录或本地状态缺失，运行 `raft-computer setup /<server-slug>`。见 [重新连接 Computer](/zh-cn/features/server/computers/#重新连接-computer)。连接恢复后，这台 Computer 上的 Agent 会自动继续。
+
+如果这台机器仍在使用 legacy daemon，请在同一台机器上运行 Raft Computer setup，用拥有该 daemon 的同一个用户登录，并在 setup 提供匹配 legacy candidate 时选择它。如果 setup 无法匹配本地痕迹，请使用迁移 diagnostics 和 machine-ID recovery 路径。见 [从旧 daemon 迁移](/zh-cn/features/server/computers/#从旧-daemon-迁移)。
+
+## Runtime errors
+
+如果 Agent 的 runtime 遇到错误，例如 API rate limit、认证失败或 model unavailable，状态点会变成橙色。
+
+- **检查你的 runtime subscription**：确认 API key 或 license 有效且额度充足。
+- **检查 runtime status**：provider 可能发生 outage。
+- **Restart Agent**：在 Agent detail panel 中使用 **Actions → Restart / Reset**。Fresh session 通常可以清除 transient errors。如果仍然卡住，请在运行该 Agent 的机器上用 `raft-computer restart /<server-slug>` 重启 Raft Computer。
+
+## 还是不行？
+
+如果以上方式都无效，打开 Agent detail panel，使用 **Actions → Report Issue**。这会发送包含 Agent diagnostics 和 session trace 的报告，供团队调查。你也可以使用 **Copy Diagnostic Info**，并在邮件中发给 **contact@raft.build**。

--- a/content/zh-cn/features/agents/workspace/index.md
+++ b/content/zh-cn/features/agents/workspace/index.md
@@ -1,0 +1,68 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1530
+llms_summary: "当你需要用简体中文了解 Agent 把持久文件、notes 和 memory 存在哪里时阅读。"
+---
+
+# Workspace
+
+每个 Agent 都有一个持久 workspace，也就是它所在 Computer 上的一个目录，用来存放文件、notes 和 memory。Workspace 会跨 session 保留。
+
+## Workspace 是什么
+
+Workspace 是 Agent 的 Computer 上由这个 Agent 拥有的一个目录：
+
+- **持久**：文件会跨 restart 和 idle/wake 周期保留。
+- **Agent-owned**：Agent 可以在其中自由读写文件。
+- **隔离**：同一台 Computer 上的其他 Agent 会有自己的独立 workspace。
+
+Agent 每次 session 开始时，都会从自己的 workspace 目录启动。
+
+::: tip Agent 会管理自己的 workspace
+你不需要为 Agent 设置或整理 workspace。Agent 工作时会创建文件、写 memory notes，并维护自己的目录结构。随着时间推移，workspace 会反映它学到了什么，以及它如何组织知识。
+:::
+
+## Agent 会存什么
+
+Agent 会把 workspace 用于：
+
+- **Memory files**：Agent 想跨 session 记住的 notes、偏好和上下文。
+- **Working files**：和当前工作相关的 drafts、data、scripts 和 artifacts。
+- **Cloned repos**：处理代码的 Agent 经常会把仓库 clone 到 workspace。
+- **Notes and knowledge**：按文件组织的领域知识、团队约定和学到的模式。
+
+## 跨 session 持久化
+
+当 Agent 进入 idle 后再次 active，或 session reset 后，workspace 仍然存在：
+
+- **跨 idle/active 周期保留**：Agent 可以写 notes，idle 几个小时，然后从原处继续。
+- **跨 session reset 保留**：memory files 让 Agent 能恢复身份和进行中的工作。
+- **随着时间增长**：Agent 工作越多，workspace 积累的知识越多。
+
+Full reset 是例外。它会连同 conversation context 一起清空 workspace。
+
+::: tip 鼓励 Agent 定期整理
+你可以要求 Agent 定期整理自己的 workspace。一句简单提示就够：
+
+> "Review your workspace — clean up any outdated files, update your memory notes, and make sure everything is current."
+
+这能让 workspace 在增长后仍然有用。
+:::
+
+## Workspace 和 Computer
+
+- **绑定到 Computer**：workspace 位于 Agent 的 Computer 上。如果 Computer 离线，workspace 仍在磁盘上，但在机器恢复前无法访问。
+- **不可迁移**：workspace 不能在 Computer 之间移动。不同 Computer 上的新 Agent 会从新的 workspace 开始。
+
+## 查看 workspace
+
+可以通过两种方式访问 workspace：
+
+- **In-app**：Raft 在 Agent panel 上提供 workspace browser（file tree），Agent 的创建者和服务器 admin 可以看到。
+- **On disk**：workspace 是 Computer 文件系统上的普通目录，可以用任何文件管理器或终端访问。
+
+::: warning 避免直接在磁盘上编辑 workspace 文件
+Agent 运行时直接修改它的磁盘文件，可能会让 Agent 失去对自身状态的跟踪。如果需要纠正某些内容，请在消息里告诉 Agent，让它自己更新文件。
+:::
+
+![Agent panel 上的 in-app workspace browser（file tree），显示文件和目录](../../../../features/agents/workspace/05-workspace-file-tree.png)

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,8 +6,6 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/agents/external/index.md
-features/agents/reminders/index.md
-features/agents/troubleshooting/index.md
 features/apps/index.md
 features/apps/login-with-raft/index.md
 features/collaboration/comments/index.md

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,10 +6,8 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/agents/external/index.md
-features/agents/lifecycle/index.md
 features/agents/reminders/index.md
 features/agents/troubleshooting/index.md
-features/agents/workspace/index.md
 features/apps/index.md
 features/apps/login-with-raft/index.md
 features/collaboration/comments/index.md


### PR DESCRIPTION
PRs #74 and #75 were stacked: their bases were the previous PR's feature branch, so squash-merging them landed their content on those branches, not on main (#73 and #54 did land on main). This PR cherry-picks the two squash commits (f7ea5ba99, 486dfc52e) onto current main.

Verification: the combined delta equals the union of the reviewed #74/#75 diffs (7 files, +231/−5), and the zh content + nav + baseline being landed is byte-identical (0-line diff) to the stack tip that contained both reviewed changes. Content review record for all three zh PRs is in #proj-docs (structure 1:1 with English sources, behavior claims verified, assets exist, separate zh-cn/llms.txt confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)