### PR TITLE
Document production OIDC Login with Raft flow

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -163,6 +163,56 @@ Server settings → Connected Apps → register a private app (or install a publ
 
 All examples use the production origins: `https://api.raft.build` (token, userinfo, serverinfo) and `https://app.raft.build` (browser authorization).
 
+### Standard OIDC clients
+
+Open WebUI, LibreChat, and other standards-based clients can use Raft as an
+OpenID Connect provider. Start with discovery rather than hard-coding endpoint
+URLs:
+
+```text
+https://api.raft.build/.well-known/openid-configuration
+```
+
+The discovery document publishes the authorization, token, userinfo, and JWKS
+endpoints, `response_type=code`, `openid`/`profile` scopes, optional `email`,
+and ES256 ID-token signing. Register the client's callback URL with the exact
+same bytes it will send at runtime. The `email` scope is optional, and must be
+included in the OAuth client's allowed scopes before Raft can grant it.
+
+An authorization request uses the standard parameters:
+
+```text
+GET https://api.raft.build/api/oauth/authorize
+  ?response_type=code
+  &client_id=<client_id>
+  &redirect_uri=<registered_callback>
+  &scope=openid%20profile%20email
+  &state=<client_state>
+  &nonce=<client_nonce>
+  &code_challenge=<S256_challenge>
+  &code_challenge_method=S256
+```
+
+`state` and `nonce` are client-generated and should be verified by the client.
+PKCE with `S256` is supported; when used, send the matching `code_verifier` to
+the token endpoint. To preselect one Raft Server, add
+`server=<server-id-or-slug>`. This only narrows the consent picker; the
+server-local OAuth client binding remains the security boundary.
+
+Raft redirects the browser to its Login with Raft setup flow and, after
+consent, back to the exact registered callback with `code` and the original
+`state`. Exchange the one-time code at
+`https://api.raft.build/api/oauth/token` using the registered client
+credentials (HTTP Basic is recommended), and send the same `redirect_uri`
+(plus `code_verifier` when PKCE is used). The response contains a bearer access
+token and a signed `id_token`. Validate the ID token's issuer, audience, expiry,
+nonce (when sent), and ES256 signature using the discovered JWKS before
+creating an app session. Use the bearer token at
+`/api/oauth/userinfo` for the current identity; `email` and `email_verified`
+appear only when the `email` scope was granted. The discovery document does
+not advertise a refresh-token flow, so start a new authorization when the
+access token expires.
+
 ## Starting a login, and the callback contract
 
 ### The setup URL

--- a/content/zh-cn/developers/login-with-raft/index.md
+++ b/content/zh-cn/developers/login-with-raft/index.md
@@ -133,6 +133,50 @@ npm create raft-app@latest my-raft-app -- --template pure-sign-in-web-app
 
 所有示例都使用生产 origin：`https://api.raft.build`（token、userinfo、serverinfo）和 `https://app.raft.build`（浏览器 authorization）。
 
+### 标准 OIDC 客户端
+
+Open WebUI、LibreChat 以及其他遵循标准的客户端可以把 Raft 当作 OpenID
+Connect Provider。请先使用 discovery，不要把 endpoint URL 硬编码：
+
+```text
+https://api.raft.build/.well-known/openid-configuration
+```
+
+Discovery 文档会发布 authorization、token、userinfo、JWKS endpoint，支持
+`response_type=code`、`openid`/`profile` scope、可选的 `email` scope，以及
+ES256 签名的 ID token。注册客户端时，回调 URL 必须与运行时发送的字节完全
+一致。`email` 是可选 scope，只有先加入 OAuth client 的 allowed scopes，Raft
+才会授予它。
+
+Authorization 请求使用标准参数：
+
+```text
+GET https://api.raft.build/api/oauth/authorize
+  ?response_type=code
+  &client_id=<client_id>
+  &redirect_uri=<registered_callback>
+  &scope=openid%20profile%20email
+  &state=<client_state>
+  &nonce=<client_nonce>
+  &code_challenge=<S256_challenge>
+  &code_challenge_method=S256
+```
+
+`state` 和 `nonce` 由客户端生成，并应由客户端验证。支持使用 `S256` 的 PKCE；
+使用时在 token endpoint 发送匹配的 `code_verifier`。如果要预选一个 Raft
+Server，可加入 `server=<server-id-or-slug>`。这只会收窄 consent picker；真正的
+安全边界仍是 server-local OAuth client binding。
+
+Raft 会把浏览器带到 Login with Raft setup 流程；同意后，再将浏览器重定向到
+注册的精确回调，并附带 `code` 及原始 `state`。使用注册的 client credentials
+（推荐 HTTP Basic）在 `https://api.raft.build/api/oauth/token` 交换一次性 code，
+并发送相同的 `redirect_uri`（使用 PKCE 时再发送 `code_verifier`）。响应包含
+Bearer access token 和签名的 `id_token`。创建应用 session 前，应使用 discovery
+得到的 JWKS 验证 ID token 的 issuer、audience、expiry、nonce（请求时提供）以及
+ES256 签名。用 Bearer token 请求 `/api/oauth/userinfo` 获取当前 identity；只有
+授予了 `email` scope 时，才会出现 `email` 和 `email_verified`。Discovery 文档不
+声明 refresh-token 流程，因此 access token 过期后应重新发起 authorization。
+
 ## 开始登录，以及 callback 契约
 
 ### Setup URL


### PR DESCRIPTION
Production Core now serves standards-compatible OIDC (#6931).

This adds bilingual developer documentation for discovery, standard authorize/token endpoints, exact redirect registration, optional email scope, server hint semantics, PKCE S256, nonce/state validation, ES256 ID-token/JWKS validation, userinfo claims, and the absence of a refresh-token flow.

Validation: pnpm build; pnpm check:agent-artifacts; pnpm check:zh-coverage (existing baseline missing pages only).