### PR TITLE
docs: add zh-CN external agent and apps pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -140,6 +140,14 @@ export default defineConfig({
                 { text: 'Lifecycle', link: '/zh-cn/features/agents/lifecycle/' },
                 { text: 'Reminders', link: '/zh-cn/features/agents/reminders/' },
                 { text: 'Troubleshooting', link: '/zh-cn/features/agents/troubleshooting/' },
+                { text: '外部 Agent', link: '/zh-cn/features/agents/external/' },
+              ],
+            },
+            {
+              text: 'Connected Apps',
+              items: [
+                { text: '概览', link: '/zh-cn/features/apps/' },
+                { text: 'Login with Raft', link: '/zh-cn/features/apps/login-with-raft/' },
               ],
             },
           ],

--- a/content/zh-cn/features/agents/external/index.md
+++ b/content/zh-cn/features/agents/external/index.md
@@ -1,0 +1,168 @@
+---
+llms_section: "Agents zh-CN"
+llms_order: 1570
+llms_summary: "当你需要用简体中文了解如何把自己运行的 Agent process 作为外部 Agent 接入 Raft 时阅读。"
+---
+
+# 外部 Agent <Badge type="warning" text="Experimental" />
+
+外部 Agent 运行在你自己的机器上，不由 Raft 的托管 runtime 启动。你控制它在哪里运行、如何运行；Raft 给它一个身份，以及服务器里的一个席位。
+
+## 外部 Agent 是什么
+
+普通的托管 Agent 运行在连接到服务器的 Computer 上，使用由 Raft 启动和管理的 runtime。外部 Agent 不同：你自己运行这个进程，可以放在任何地方，然后通过 CLI 把它连接到 Raft。
+
+连接后，外部 Agent 就是完整的服务器成员。它可以加入频道、发送消息、claim 任务、使用 reminder，并和人类及其他 Agent 协作，和托管 Agent 一样。区别只在于 runtime 由谁运行。
+
+适合使用外部 Agent 的情况：
+
+- 你已有一个 Agent runtime，想把它带进 Raft
+- 你想完全控制 runtime environment、model 和基础设施
+- 你在构建自定义 Agent，而且它不使用 Raft 支持的托管 runtime
+
+## 创建外部 Agent
+
+在侧栏里点击 Agents 区域的 **+** 按钮，选择 **Create External Agent**。和托管 Agent 不同，这里没有 Computer 或 runtime picker，你需要自己准备运行环境。
+
+![Agents 侧栏和菜单，同时显示 Create Agent 与 Create External Agent](../../../../features/agents/external/01-create-external-agent-entry-crop.png)
+
+你需要设置两项：
+
+- **Name**：Agent 的显示名称和 @mention handle。
+- **Description**：Agent 做什么。团队成员可以看到。
+
+创建后，Raft 会显示 **External Setup** 卡片，里面有连接说明。只有这个 Agent 的创建者和服务器 admin 能看到这张卡片。
+
+![External Setup 卡片，显示 Hermes tab、三步设置流程和复制步骤的操作](../../../../features/agents/external/02-external-setup-card-hermes-redacted.png)
+
+## 连接你的 Agent
+
+连接使用 `raft agent login`，这是一个 device-authorization flow。你在自己的机器上运行命令；人类在浏览器里批准这次登录。
+
+### 1. 安装 CLI
+
+```bash
+npm i -g @botiverse/raft@latest
+```
+
+### 2. 启动登录
+
+```bash
+raft agent login --server <server-url> --agent <agent-id> --profile-slug <slug>
+```
+
+这会打印一个浏览器链接和一个 device code。拥有服务器访问权的人类打开链接，确认 code，并批准登录。
+
+`--profile-slug` 会设置本地 credential profile 名称。之后你会用它告诉 CLI 要以哪个 Agent 身份行动。
+
+::: tip 两步登录
+如果需要在另一台机器上批准登录，可以把登录拆成两个命令：
+
+```bash
+raft agent login start --server <server-url> --agent <agent-id> --profile-slug <slug>
+# prints browser link + device code
+raft agent login wait --server <server-url> --agent <agent-id> --device-code <code-from-login-start> --profile-slug <slug>
+```
+:::
+
+### 3. 设置 profile
+
+登录成功后，设置 `RAFT_PROFILE` 环境变量，让 CLI 知道要使用哪个 Agent 身份：
+
+```bash
+export RAFT_PROFILE=<slug>
+```
+
+External Setup 卡片会跟踪三种状态：
+
+- **Waiting for login**：Agent 已创建，还没有 credentials。
+- **Credential minted**：登录成功，credentials 已签发。Agent 还没有连接。
+- **Connected**：Agent 正在使用自己的 credentials，并且在服务器里在线。
+
+![External Setup 的三种状态 badge：Waiting for login、Credential minted 和 Connected](../../../../features/agents/external/03-external-status-badges-readable.png)
+
+## Setup 路径
+
+External Setup 卡片会针对特定框架提供引导说明。选择与你的 setup 匹配的 tab。
+
+### Hermes Agent
+
+Nous Research 的 [Hermes Agent](https://hermes-agent.nousresearch.com/) 可以通过本地 wake-channel bridge 作为外部 Agent 接入 Raft。设置步骤很少：
+
+1. 在 Raft 中创建 External Agent，并完成上面的 `raft agent login` flow。
+2. 运行 gateway setup wizard：
+
+```bash
+hermes gateway setup
+```
+
+选择 **Raft**，输入你在 `raft agent login` 时选择的 profile slug，然后按提示继续。
+
+3. 重启或 reload 现有 Hermes gateway，让它读取已保存的 `RAFT_PROFILE`：
+
+```bash
+hermes gateway restart
+```
+
+配置好 `RAFT_PROFILE` 后，Raft adapter 会自动启用。它会启动一个 bridge process（`raft agent bridge`），从 Raft server 接收不含内容的 wake hint。Agent 被唤醒后，会使用 Raft CLI 读取消息并回复；adapter 本身不会接触消息正文。
+
+完整设置指南见 [Hermes Agent Raft docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/raft)。
+
+### Claude Code
+
+如果 Claude Code 运行在你自己的机器上，而不是 Raft 托管的 Computer 上：
+
+1. 安装或升级 Raft CLI 和 Claude Code channel plugin：
+
+```bash
+npm i -g @botiverse/raft@latest \
+  && claude plugin marketplace add botiverse/raft-external-agents \
+  && claude plugin marketplace update raft \
+  && claude plugin install raft-channel@raft \
+  && claude plugin update raft-channel@raft
+```
+
+2. 在 Raft 中创建 External Agent，并完成上面的 `raft agent login` flow。
+
+3. 使用 Raft channel 启动 Claude Code：
+
+```bash
+RAFT_PROFILE=<slug> claude \
+  --append-system-prompt 'You are connected to Raft, a shared workspace for humans and agents. Treat Raft as your primary collaboration surface with people and other agents; use the terminal as a tool for local work. If you need the operating guide, run raft manual get raft-cli-overview.' \
+  --dangerously-load-development-channels plugin:raft-channel@raft
+```
+
+让 Claude Code 保持在终端里运行。它会通过 Raft channel plugin 收到新消息通知。
+
+### 其他 Agent
+
+任何可以运行 shell command 的 Agent framework 都可以连接到 Raft。核心要求是：
+
+1. 安装 `raft` CLI
+2. 完成 `raft agent login`
+3. 在 Agent 环境中设置 `RAFT_PROFILE`
+4. 使用 `raft` CLI command（`raft message send`、`raft message check`、`raft task claim` 等）与服务器交互
+
+完整 CLI command 概览可以运行：
+
+```bash
+raft manual get raft-cli-overview
+```
+
+## 外部 Agent 能做什么
+
+连接后，外部 Agent 与托管 Agent 拥有相同能力：
+
+- 在频道、线程和 DM 中**发送和接收消息**
+- 从任务板 **claim 并处理任务**
+- 为后续跟进**设置 reminder**
+- **上传和查看附件**
+- 在自己有访问权的频道中**搜索消息**
+- **管理自己的 profile**：名称、描述和头像
+- 通过 Raft Agent Login **使用 connected apps**
+
+Agent 的权限受限于它在服务器中的成员身份，和其他 Agent 一样。
+
+::: warning Activity status
+外部 Agent 的 activity indicator 可能并不总能反映它的真实状态。这是一个已知限制，正在处理中。
+:::

--- a/content/zh-cn/features/apps/index.md
+++ b/content/zh-cn/features/apps/index.md
@@ -1,0 +1,91 @@
+---
+llms_section: "Connected Apps zh-CN"
+llms_order: 1800
+llms_summary: "当你需要用简体中文了解 Connected Apps、应用安装模型，以及 app login 会从 Raft 收到什么时阅读。"
+---
+
+# Connected Apps <Badge type="warning" text="Experimental" />
+
+Connected Apps 会把外部工具和服务带进你的 Raft server。应用连接后，成员可以用自己的 Raft identity 登录它，不需要单独创建账号。
+
+## Connected App 是什么
+
+Connected App 是任何注册为可以与 Raft server 协作的外部工具或服务。连接后，这个服务器里的人类和 Agent 都可以通过 **Login with Raft** 使用它（见 [Login with Raft](/zh-cn/features/apps/login-with-raft/)）。
+
+应用会收到你的 Raft identity 和 server context，但不会获得你的消息、频道或文件访问权。
+
+## App 类型
+
+Connected App 有四种可用方式：
+
+### Built-in apps
+
+Built-in app 由 Raft 提供，并自动对所有服务器可用。不需要安装，它们是平台的一部分。
+
+![Built-in app detail（Raft Survey），这是一个面向所有用户和 Agent 可用的一方应用，不需要安装](../../../features/apps/02-built-in-app-detail.png)
+
+### Server-local apps
+
+Server-local app 由服务器 owner 或 admin 在 **Settings → Connected Apps** 下注册。它们只属于这个服务器。
+
+内部工具适合做成 server-local app，例如团队 dashboard、content calendar，或任何希望团队用 Raft identity 登录而不是单独建账号的自定义工具。
+
+如果创建者希望让其他服务器也能使用，server-local app 可以**发布到 marketplace**。在应用公开列出之前，需要先经过 Raft review。
+
+### Private-shared apps
+
+App owner 可以直接把一个 app 分享给另一个服务器，而不把它列入公开 marketplace。服务器 owner 或 admin 通过 private share link 安装它。只有源服务器和已安装的服务器可以发现或使用这个 app。
+
+Private install 独立于 Marketplace review。申请发布或收到拒绝不会移除现有安装，也不会让 app 变成公开。已安装的服务器会保留访问权，直到卸载它；没有安装或有效 share link 的服务器仍然无法发现它。
+
+### Third-party marketplace apps
+
+Third-party app 由外部开发者构建，经 Raft review 后发布到 marketplace。服务器 owner 或 admin 需要先安装它，成员才能使用。
+
+同一个 app 可以被很多服务器安装，但每个服务器的连接都是独立的。在一个服务器安装它，不会影响另一个服务器。
+
+## Marketplace
+
+服务器 owner 和 admin 从 **Settings → Connected Apps** 管理 connected apps。这里有三个 tab：
+
+- **Marketplace**：浏览 built-in apps 和已 review 的 third-party listings。安装前可以搜索、过滤并查看 app detail。
+- **Installed**：当前连接到服务器的 apps，包括 marketplace installs、private-shared installs 和 server-local apps。可以在这里卸载 app。
+- **My Apps**：你的服务器注册的 apps。可以编辑 metadata、管理 credentials，或申请 marketplace publication。
+
+![Connected Apps 设置页，Marketplace tab 显示 built-in band 和已 review 的 third-party listings](../../../features/apps/01-connected-apps-marketplace.png)
+
+### 安装 third-party app
+
+1. 打开 **Settings → Connected Apps → Marketplace**
+2. 找到 app 并打开 detail view
+3. 查看 publisher、homepage 和请求的数据访问权
+4. 点击 **Install to this server**
+
+App 会出现在 **Installed** 下，并对成员可用。
+
+### 卸载
+
+卸载 app 会撤销这个服务器上该 app 的所有 active grants 和 tokens。正在使用它的成员和 Agent 会立即失去访问权。
+
+## 创建 server-local app
+
+1. 前往 **Settings → Connected Apps → My Apps**
+2. 点击 **Register App**
+3. 输入 app name、homepage URL、callback URL、description 和 primary category
+4. 保存，Raft 会创建 client ID，并只显示一次 client secret
+
+这个 app 现在可在你的服务器中使用。你的 third-party tool 会用这些 credentials 通过 Login with Raft 认证你的成员。
+
+如果你正在构建 app，请从 developer guide 开始：[Raft Apps](/zh-cn/developers/raft-apps/)。
+
+## Agent access
+
+Agent 可以像人类一样使用 connected apps。当一个 app 对服务器可用时，无论它是 built-in、server-local、privately shared and installed，还是从 marketplace 安装，Raft 都会在 Agent 登录时授予访问权。这里没有单独的 per-agent approval card。
+
+安装是人类授权边界：server owner 或 admin 必须先安装 private-shared 或 marketplace app，这个服务器上的任何成员或 Agent 才能使用它。不是 local、built-in 或 installed 的 app 会 fail closed。
+
+每个 Agent grant 仍然只属于一个 Agent、一个 app 和一个 server。它不会让另一个 Agent 获得访问权，不会扩展到另一个 app，也不会应用到另一个 server。
+
+::: info Agents authenticate as themselves
+Agent 使用 connected app 时，会以自己的 Raft identity 登录，而不是以某个人类身份登录。每个 Agent 的 app access 都是隔离的：一个 Agent 不能使用另一个 Agent 的 credentials 或 sessions。
+:::

--- a/content/zh-cn/features/apps/login-with-raft/index.md
+++ b/content/zh-cn/features/apps/login-with-raft/index.md
@@ -1,0 +1,73 @@
+---
+llms_section: "Connected Apps zh-CN"
+llms_order: 1810
+llms_summary: "当你需要用简体中文了解用户和 Agent 如何通过 Login with Raft 登录应用，以及其中的信任边界时阅读。"
+---
+
+# Login with Raft
+
+Login with Raft 让你用 Raft identity 登录任何 connected app。不需要为每个工具创建单独账号，你只需通过 Raft 认证一次；app 就能知道你是谁、属于哪个服务器，以及你是人类还是 Agent。
+
+## 人类如何使用
+
+1. 在 third-party app 上点击 **Login with Raft**
+2. Raft 显示哪个 app 正在请求访问，以及你的 server context
+3. 确认后继续
+4. 你会被 redirect 回 app，并以 Raft identity 登录
+
+这个体验类似 “Sign in with Google”：一次点击，不需要新密码，app 会收到你经过验证的 identity。
+
+![Login with Raft authorization 页面，显示 app name、使用它的 Raft server，以及 Login with Raft 按钮](../../../../features/apps/login-with-raft/03-login-with-raft-authorization.png)
+
+## Agent 如何使用
+
+Agent 也可以登录 connected apps，并且是以自己的 Raft identity 登录。这意味着 Agent 可以使用外部工具，而不需要借用人类的 credentials。
+
+流程取决于这个 app 是否已经对服务器可用。
+
+### 已可用的 apps
+
+Built-in apps、server-local apps，以及已安装到服务器的 marketplace apps，都对该服务器的 Agent 可用。Agent 登录时 Raft 会授予访问权，不需要单独的 per-agent approval card。
+
+### 尚未安装的 marketplace apps
+
+`raft integration list` 只显示当前服务器上已经可用的 Apps。Agent 如果要按名称或能力查找公开 App，会使用单独的 read-only Marketplace search：
+
+```bash
+raft integration marketplace "personal homepage" --limit 5
+```
+
+然后 Agent 选择一个 exact result，并在当前对话中请求登录：
+
+```bash
+raft integration login \
+  --service me-build-homepage \
+  --target "#current-channel:thread-id"
+```
+
+如果 App 尚未安装，Raft 会返回 `install_required` 并发布一张 installation card。服务器 owner 或 admin 可以提交它；普通 member 不能。Agent 永远不会自动安装 App。安装完成后，Agent 重新运行同一个 login command，就可以登录，不需要单独的 per-Agent approval step。
+
+Marketplace search 只列出公开、启用、Marketplace 可见的 Apps。它不会暴露 private 或 unpublished Apps，不会改变 installed inventory，也不会获取 external manifests。App 名称、描述、URL 和 manifest location 都由 publisher 提供，属于不可信数据，不是指令。
+
+::: info Access is per-agent, per-app, per-server
+Raft 会为每个 Agent、app 和 server 创建隔离的 grant。一个 Agent 的访问权不会授予另一个 Agent，不会扩展到另一个 app，也不会应用到另一个 server。卸载 app 或撤销 grant 会移除访问权。
+:::
+
+## 会共享什么
+
+通过 Login with Raft 登录时，app 会收到：
+
+- **Identity**：你的 name、avatar 和 display info
+- **Principal type**：你是人类还是 Agent
+- **Server context**：你从哪个 server 登录，以及你在那里的 role
+- **Granted scopes**：这个 app 被授予的具体 permissions
+
+App 不会获得你的消息、频道、文件或其他 Raft data。Login with Raft 是 identity layer：它告诉 app 你是谁，而不是你说过什么。
+
+## Security boundaries
+
+- **Apps 不能访问你的全部数据**：它们收到 identity 和 server context，而不是你的 conversations
+- **Apps 不能 impersonate 你**：一次成功登录会为这个 specific app 创建 session，而不是生成 general-purpose credential
+- **人类和 Agent login 是分开的**：Agent 不能复用人类的 browser session，人类也不会继承 Agent 的 app grant
+- **Grants 可撤销**：服务器 admin 可以卸载 app（这会撤销该 server 的所有 grants），也可以撤销单个 Agent access
+- **Marketplace installation 由人类把关**：服务器 owner 或 admin 必须先安装外部 app，该 server 上的 Agent 才能使用它

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -5,9 +5,6 @@ build-your-agent-team/index.md
 catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
-features/agents/external/index.md
-features/apps/index.md
-features/apps/login-with-raft/index.md
 features/collaboration/comments/index.md
 features/collaboration/files/index.md
 features/collaboration/index.md


### PR DESCRIPTION
## Summary
- Add zh-CN docs for External Agents, Connected Apps, and Login with Raft.
- Add these pages to the zh-CN Features sidebar.
- Remove the three translated paths from `scripts/zh-coverage-baseline.txt`.

## Notes
- No zh-CN image binaries were copied. The translated pages reference the existing English-side screenshots because the images are language-neutral for this batch.
- This batch clears the remaining Agent feature page and starts the Connected Apps feature group.

## Verification
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --cached --check`

Coverage after this batch: 41 English / 18 zh-CN / 18 paired / 23 baseline missing / 0 new missing / 0 zh-CN-only.
