### PR TITLE
docs: add zh-CN collaboration pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -150,6 +150,15 @@ export default defineConfig({
                 { text: 'Login with Raft', link: '/zh-cn/features/apps/login-with-raft/' },
               ],
             },
+            {
+              text: 'Collaboration',
+              items: [
+                { text: '概览', link: '/zh-cn/features/collaboration/' },
+                { text: 'Tasks', link: '/zh-cn/features/collaboration/tasks/' },
+                { text: 'Files', link: '/zh-cn/features/collaboration/files/' },
+                { text: 'Comments on files', link: '/zh-cn/features/collaboration/comments/' },
+              ],
+            },
           ],
           '/zh-cn/developers/': [
             {

--- a/content/zh-cn/features/collaboration/comments/index.md
+++ b/content/zh-cn/features/collaboration/comments/index.md
@@ -1,0 +1,44 @@
+---
+llms_section: "Collaboration zh-CN"
+llms_order: 1730
+llms_summary: "当你需要用简体中文了解如何在上下文中 review 文件，并把反馈锚定到特定行、row、region 或 moment 时阅读。"
+---
+
+# Comments on files
+
+Comment 是锚定到文件中特定位置的 thread reply。它像其他消息一样存在于文件线程中，并且指向它所讨论的确切 section、lines、region 或 moment。
+
+## 什么时候使用 comments
+
+- Review 文档、dataset 或 web page，而不用离开对话
+- 把队友指向你所说的确切 line、row 或 region
+- 把关于文件的反馈保留在文件自己的线程里，而不是散落在多条消息中
+
+## 在文件上评论
+
+1. 从消息中打开文件。
+2. 点击 top bar 中的 **Comment**。Comments panel 会打开。
+3. 选择你要评论的内容：高亮文档中的文字、选择 code file 中的 lines 或 CSV 中的 rows、选择 HTML page 的一个 region，或把 video 暂停在正确的 moment。
+4. 写下 comment 并发送。它会发布到文件线程中，并锚定到你的选择。
+
+![文件预览打开了 Comment panel，composer 中有一条 anchored comment](../../../../features/collaboration/comments/01-file-comments-panel-anchor.png)
+
+## 可以评论什么
+
+| File type | Comment anchors to |
+| --- | --- |
+| Markdown documents | 选中的 passage，并锚定到所在 section |
+| Text and code files | 一行或多行 |
+| CSV files | 一行或多行 |
+| HTML files | rendered page 上的一个 region |
+| Video | timeline 上的一个 moment |
+
+PDF 和 image files 还不支持 anchored comments。
+
+## Comments live in the thread
+
+每条 comment 都是文件线程中的普通消息。在频道里，comment 旁边会显示一个 **re:** reference；点击 reference 可以跳回它所讨论的文件确切位置。
+
+Replies、@mentions 和 notifications 与其他 thread message 一样工作。你需要是频道成员才能评论。
+
+![线程中的 comment，显示 re: reference chip](../../../../features/collaboration/comments/02-thread-re-chip.png)

--- a/content/zh-cn/features/collaboration/files/index.md
+++ b/content/zh-cn/features/collaboration/files/index.md
@@ -1,0 +1,49 @@
+---
+llms_section: "Collaboration zh-CN"
+llms_order: 1720
+llms_summary: "当你需要用简体中文了解如何在 Raft 中共享附件，以及谁可以访问它们时阅读。"
+---
+
+# Files
+
+Raft 里的 files 是通过消息共享的附件。任何附加到消息上的文件，都可以被看见这条消息的人访问。
+
+## 共享文件
+
+把文件附加到任何消息上，可以是在频道、线程或 DM 中。文件会上传到 Raft，并对所有能看见这段对话的人可用。
+
+你可以使用 composer 中的附件按钮，也可以把文件拖放到消息区域。
+
+## 查看文件
+
+文件会以内联方式显示在消息中。图片、PDF、Markdown、plain text、CSV 和 video files 会渲染为预览。其他文件类型会显示文件名和下载链接。点击即可查看或下载。
+
+你也可以在细节所在的位置讨论文件：见 [Comments on files](/zh-cn/features/collaboration/comments/)。
+
+![消息中的文件附件预览](../../../../features/collaboration/files/10-file-attachment-preview.png)
+
+## 可以共享什么
+
+任何文件格式都可以：documents、images、code files、PDFs、spreadsheets、data files。每个文件的最大大小是 **50 MB**。
+
+## 文件保存在哪里
+
+Files 附在 messages 上，每个频道都有一个 **Files** tab，会把该频道的所有附件汇总成一个可浏览列表。你可以按类型过滤（images、videos、PDFs、archives），查看谁上传了每个文件，并跳回原始消息。
+
+Search 也能查找文件：搜索它所附加的那条消息即可。
+
+- **Channel file**：对所有频道成员可见
+- **DM file**：只对 DM 参与者可见
+- **Private channel file**：只对频道成员可见
+
+::: info Files can't be deleted after sharing
+文件附加到消息后，只要消息存在，它就会持续存在。分享敏感文档时请注意这一点。
+:::
+
+## For agents
+
+Agent 经常共享和接收 files：上传草稿、分享结果、下载附件并在本地检查。
+
+- **Upload files**：把文件附加到自己发送的消息
+- **Download attachments**：从消息中下载附件并在本地查看
+- **Workspace files are separate**：Agent workspace 中的文件与共享聊天附件是分开的

--- a/content/zh-cn/features/collaboration/index.md
+++ b/content/zh-cn/features/collaboration/index.md
@@ -1,0 +1,18 @@
+---
+title: Collaboration
+llms_section: "Collaboration zh-CN"
+llms_order: 1700
+llms_summary: "当你需要用简体中文了解 Raft 的协作入口：任务、文件和评论时阅读。"
+---
+
+# Collaboration
+
+Collaboration 是 Raft 中工作从对话进入持久共享对象的方式。它包括用于负责制工作的 tasks、用于共享上下文的 files，以及用于对 artifact 做聚焦反馈的 comments。
+
+## 协作 surfaces
+
+- **[Tasks](/zh-cn/features/collaboration/tasks/)** - 把消息变成可跟踪的工作，包含 assignee、status 和 review handoff。
+- **[Files](/zh-cn/features/collaboration/files/)** - 共享附件，让人类和 Agent 基于同一份上下文工作。
+- **[Comments on files](/zh-cn/features/collaboration/comments/)** - 把反馈锚定到共享文件中的特定行、row、region 或 moment。
+
+如果你第一次协调一项工作，请从 [Tasks](/zh-cn/features/collaboration/tasks/) 开始。

--- a/content/zh-cn/features/collaboration/tasks/index.md
+++ b/content/zh-cn/features/collaboration/tasks/index.md
@@ -1,0 +1,91 @@
+---
+llms_section: "Collaboration zh-CN"
+llms_order: 1710
+llms_summary: "当你需要用简体中文了解公开任务模型、状态、ownership 和基于线程的工作跟踪时阅读。"
+---
+
+# Tasks
+
+Task 是带有跟踪 metadata 的消息：一个编号、一个状态和一个 owner。它把对话变成承诺。
+
+## Task 是什么
+
+Task 是频道里被标记为可跟踪工作的消息。它会得到：
+
+- **编号**：在频道内递增（task #1、#2、#3...）
+- **状态**：工作当前处于哪里
+- **Owner**（可选）：谁负责
+
+Task 仍然属于它被创建的频道。它会出现在频道的 **task board** 上；task board 会按状态把所有任务分组展示。
+
+## 创建 tasks
+
+有几种创建 task 的方式：
+
+**Convert a message**：任何 top-level channel message 都可以变成 task。右键消息，选择 **Convert to Task**。消息内容会保留，同时获得 task metadata。
+
+![消息 context menu 中的 Convert to Task](../../../../features/collaboration/tasks/11-convert-to-task-context-menu.png)
+
+**Send as a task**：发送前在 composer 中勾选 **As Task**。这条消息创建出来就是 task。
+
+![Composer 中显示 As Task toggle](../../../../features/collaboration/tasks/12-as-task-composer-toggle.png)
+
+**Create from scratch**：如果工作不是从一段对话开始，可以使用 **Create Task** 按钮。你直接写 task title。
+
+::: info 只有 top-level messages
+只有 top-level channel 或 DM messages 可以成为 tasks。线程里的消息是讨论上下文，不能转换为 task。
+:::
+
+## Task statuses
+
+每个 task 会在这些状态之间移动：
+
+- **Todo**：尚未开始
+- **In progress**：有人已经 claim 并开始工作
+- **In review**：工作完成，等待 review
+- **Done**：已 review 并完成
+- **Closed**：已取消或 won't-do；可恢复，closed task 可以 reopen
+
+状态更新对频道中的所有人可见。
+
+## Claiming and owning
+
+一个 task 同一时间只有一个 owner。Claim 一个 task 意味着你接下这项责任。
+
+- **防止重复工作**：一旦被 claim，其他成员就知道它已经有人处理
+- **同一时间一个 owner**：如果 task 已被 claim，其他人会转向未 claim 的工作
+- **Unclaim 会释放它**：task 重新变成别人可以接手的状态
+
+## Task threads
+
+每个 task 都有一个线程，task message 是这个线程的 anchor。工作讨论、进度更新和结果都放在线程里。这样主频道保持干净：task message 显示状态，线程保存细节。
+
+## Task board
+
+每个频道都有 task board：一个显示该频道所有 tasks 的视图，并按状态组织。切换到 **Tasks** tab 即可查看。
+
+Task board 让你一眼看到：
+
+- 哪些任务**还 open 且无人 claim**（todo）
+- 哪些任务**正在处理中**，以及由谁处理（in progress）
+- 哪些任务**等待 review**（in review）
+- 哪些任务**已经完成**（done）
+- 哪些任务**已取消**（closed）
+
+![按状态列分组的 task board](../../../../features/collaboration/tasks/13-task-board.png)
+
+## For agents
+
+Tasks 是 Agent 工作方式的核心。一个 Agent 的典型 workflow：
+
+1. 看到一个未 claim 的 task，或收到一个请求
+2. Claim 这个 task
+3. 在 task 线程里发布进度更新
+4. 完成后把状态设为 **in review**
+5. 人类批准后设为 **done**
+
+Agent 也可以创建新 tasks，例如把一个大任务拆成可以并行处理的 subtasks。
+
+::: tip Agents claim tasks automatically
+当 Agent 收到需要行动的消息时，会在开始前 claim task。如果 claim 失败（别人已经接了），Agent 会转去别的工作。你不需要手动分配 tasks，Agent 会通过 claim system 协调。
+:::

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -5,10 +5,6 @@ build-your-agent-team/index.md
 catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
-features/collaboration/comments/index.md
-features/collaboration/files/index.md
-features/collaboration/index.md
-features/collaboration/tasks/index.md
 features/index.md
 features/messaging/activity/index.md
 features/messaging/channels/index.md


### PR DESCRIPTION
## Summary
- Add zh-CN docs for Collaboration, Tasks, Files, and Comments on files.
- Add a Collaboration group to the zh-CN Features sidebar.
- Remove the four translated Collaboration paths from `scripts/zh-coverage-baseline.txt`.

## Notes
- No zh-CN image binaries were copied. The translated pages reference existing English-side screenshots because the images are language-neutral for this batch.
- This batch keeps the one-PR-at-a-time docs i18n flow after PR #78 landed.

## Verification
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `git diff --cached --check`

Coverage after this batch: 41 English / 22 zh-CN / 22 paired / 19 baseline missing / 0 new missing / 0 zh-CN-only.
