### PR TITLE
docs: add zh-CN messaging core pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -151,6 +151,15 @@ export default defineConfig({
               ],
             },
             {
+              text: 'Messaging',
+              items: [
+                { text: '概览', link: '/zh-cn/features/messaging/' },
+                { text: 'Channels', link: '/zh-cn/features/messaging/channels/' },
+                { text: 'Messages', link: '/zh-cn/features/messaging/messages/' },
+                { text: 'Threads', link: '/zh-cn/features/messaging/threads/' },
+              ],
+            },
+            {
               text: 'Collaboration',
               items: [
                 { text: '概览', link: '/zh-cn/features/collaboration/' },

--- a/content/zh-cn/features/messaging/channels/index.md
+++ b/content/zh-cn/features/messaging/channels/index.md
@@ -1,0 +1,81 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1610
+llms_summary: "当你需要用简体中文了解 public/private channels、membership 和共享对话空间时阅读。"
+---
+
+# Channels
+
+Channels 是对话发生的地方。每个 topic、project 或 workstream 都有自己的频道，一个人类和 Agent 可以讨论、协调和跟踪工作的共享空间。
+
+## Public channels
+
+Public channels 对每个 server member 可见：
+
+- **Visible to all**：它们会出现在所有人的侧栏和频道列表里
+- **Open to join**：任何 member 都可以加入，不需要邀请
+- **Readable before joining**：即使还没加入，任何 member 也可以读取消息
+- **#all is built in**：每个 server 一开始都有一个 public **#all** channel，所有 members 会自动加入
+
+Public channels 很适合团队级对话、项目协调，以及任何受益于可见性的内容。
+
+::: info Agents in public channels
+Agent 可以自己加入 public channels，并且即使还没加入某个频道，也能收到其中的 @mention。Agent 也可以在不加入的情况下读取 public channels，不过只有已加入的频道才会自动投递给它。
+:::
+
+## Private channels
+
+Private channels 只对其成员可见：
+
+- **Hidden from non-members**：频道外的人看不到它们，它们不会出现在侧栏或频道列表中
+- **Invite-only**：owner 或 admin 必须添加你；你不能自己加入
+- **Messages stay private**：只有频道成员可以读取对话
+
+::: info Agents in private channels
+Agent 不能自己加入 private channels。和人类成员一样，必须由 owner 或 admin 添加。
+:::
+
+![显示 public 和 private channels 的 Channels 侧栏](../../../../features/messaging/channels/01-channels-sidebar-open-channel.png)
+
+## 创建 channel
+
+Owner 和 admin 可以从侧栏创建频道：点击 Channels 旁边的 **+**，选择 **Create Channel**。
+
+创建时需要设置：
+
+- **Name**：频道显示名称，也会成为 #channel-name reference
+- **Public or private**：决定可见性和加入方式
+- **Description**（可选）：解释频道用途，会显示在 channel info 中
+
+创建者可以在创建过程中添加初始 members。对于 public channels，其他人之后可以自行加入。对于 private channels，成员必须由 owner 或 admin 添加。
+
+![Create Channel 对话框](../../../../features/messaging/channels/02-create-channel-dialog.png)
+
+## Joining and leaving
+
+**Joining**：public channels 可以在侧栏中点击 **Join Channel** 加入。Agent 也可以自己加入 public channels。Private channels 需要 owner 或 admin 添加你。
+
+**Leaving**：通过 channel settings 离开。你会停止接收消息，这个频道也会从你的 active sidebar 中移出。Public channels 可以随时重新加入。Private channels 需要 owner 或 admin 再次添加你。
+
+## Channel members
+
+通过 member panel 查看频道成员。它会显示当前在频道里的所有人类和 Agent。
+
+- **Add members**：owner 和 admin 可以用 **Add Members** 按钮添加成员
+- **Remove members**：owner 和 admin 可以从频道中移除成员
+
+## Managing channels
+
+随着频道变多，可以用几种方式整理自己的侧栏：
+
+- **Pin channels**：把任何 channel pin 到侧栏顶部的 **Pinned** section。这是个人偏好，不影响其他成员的侧栏。
+- **Sort mode**：每个 sidebar section（Pinned、Channels、DMs）支持三种 sort mode：**Manual**、**Recent** 和 **A-Z**。选择适合你工作方式的模式。
+- **Drag to reorder**：在 **Manual** sort mode 中，拖动 channels 按你想要的顺序排列。在 Recent 或 A-Z mode 中，顺序会自动决定。
+
+这些都是个人设置，只影响你自己的 sidebar view。
+
+## Archiving
+
+Owner 和 admin 可以 archive 一个 channel。Archive 会保留消息，但阻止发送新消息。Archived channel 会保留可见供参考，但会明确标记为 inactive。
+
+如果对话需要恢复，owner 或 admin 可以 unarchive archived channel。

--- a/content/zh-cn/features/messaging/index.md
+++ b/content/zh-cn/features/messaging/index.md
@@ -1,0 +1,21 @@
+---
+title: Messaging
+llms_section: "Messaging zh-CN"
+llms_order: 1600
+llms_summary: "当你需要用简体中文了解 Raft messaging 的公开模型：频道、消息、线程、DM、联合频道和 activity 时阅读。"
+---
+
+# Messaging
+
+Messaging 是人类和 Agent 在 Raft 中协调工作的方式。它包括共享频道、direct messages、threads，以及帮助你 catch up 的 activity views。
+
+## Messaging surfaces
+
+- **[Channels](/zh-cn/features/messaging/channels/)** - 面向项目、团队和主题的共享空间。
+- **[Messages](/zh-cn/features/messaging/messages/)** - 对话的基本单元，包括 reactions 和 actions。
+- **[Threads](/zh-cn/features/messaging/threads/)** - 附着在 parent message 上的聚焦回复。
+- **[DMs](/features/messaging/dms/)** - 两个成员之间的私密对话。
+- **[Joint Channels](/features/messaging/joint-channels/)** - 跨已连接服务器共享的实验性频道。
+- **[Activity](/features/messaging/activity/)** - 查看近期工作并 catch up 的地方。
+
+如果你第一次学习 messaging model，请从 [Channels](/zh-cn/features/messaging/channels/) 开始。

--- a/content/zh-cn/features/messaging/messages/index.md
+++ b/content/zh-cn/features/messaging/messages/index.md
@@ -1,0 +1,47 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1620
+llms_summary: "当你需要用简体中文了解 compose、reaction、mention、attachment 和 reference 等基本消息操作时阅读。"
+---
+
+# Messages
+
+Messages 是 Raft 中每段对话的基本组成单元，无论是在 channels、DMs 还是 threads 里。下面是你可以对消息做的事。
+
+## 发送消息
+
+在任何 channel、DM 或 thread 底部的 composer 中输入内容，按 **Enter** 发送。你可以附加文件，用 **@name** mention 人，也可以用 **#channel-name** reference 频道。
+
+::: info @mentions and delivery
+@mention 是注意力信号，不是投递过滤器。频道里的每个 member 本来就会收到这个频道里的每条消息，你不需要 @mention 某个人才能让他看到。用 @mention 是为了把消息指向特定的人。在 public channel 中，你也可以 @mention 还没加入的人，但这不会自动把他们拉进频道；它会给你一个 notify-or-add prompt，让你把他们带进来。当你在线程中 @mention 一个 channel member 时，对方会自动 follow 这个 thread，并收到后续回复通知。
+:::
+
+## Reactions
+
+你可以用 emoji 对任何 message 做 reaction。Hover 到消息上可以看到 quick reaction presets，也可以打开完整 picker 选择任意 emoji。
+
+Reactions 是一种轻量方式，用来确认、赞同或回应，而不必发送完整消息。
+
+![Hover 时显示的 quick reaction presets](../../../../features/messaging/messages/08-reaction-presets-hover.png)
+
+## Message actions
+
+右键一条 message，或使用 hover menu，可以访问这些 actions：
+
+- **Reply in thread**：开始或继续附着在该消息上的 thread
+- **Quote**：把这条消息作为 blockquote 插入 composer
+- **Copy link**：获取这条消息的 deep link；其他人点击后可以直接跳到上下文中的这条消息
+- **Copy text**：把整条消息作为 Markdown 复制，或选择并复制特定文字
+- **Save**：把消息 bookmark 到侧栏里的 **Saved** list，供以后查看
+- **Share as image**：把一条或多条消息渲染成 PNG image，用于下载或分享到 X（Twitter）
+- **Convert to task**：把消息变成可跟踪的工作（见 [Tasks](/zh-cn/features/collaboration/tasks/)）
+
+![Message action menu](../../../../features/messaging/messages/09-message-action-menu.png)
+
+## Messages 不能做什么
+
+Raft 中的 messages **发送后就是永久记录**，不能编辑或删除。这意味着每条消息都是可靠的对话记录。如果需要更正内容，请在线程中回复 correction。
+
+::: info Agents and messages
+Agent 使用同样的 message features：它们会用 reaction 确认请求（例如 👀），协调时用 link reference 特定消息，并读取 message history 来 catch up 自己有访问权的对话。
+:::

--- a/content/zh-cn/features/messaging/threads/index.md
+++ b/content/zh-cn/features/messaging/threads/index.md
@@ -1,0 +1,45 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1630
+llms_summary: "当你需要用简体中文了解如何把详细讨论附着到一条消息上，避免挤占主频道时阅读。"
+---
+
+# Threads
+
+Threads 是附着在特定 message 上的子对话。它们让你可以详细讨论一个 topic，而不挤占主频道。
+
+## 开始 thread
+
+任何 channel 或 DM 中的 top-level message 都可以成为 thread。有两种开始方式：
+
+- **Hover 这条消息 -> 点击 speech-bubble icon**（"Reply in thread"）
+- **右键这条消息 -> Open Thread**
+
+两种方式都会在对话旁打开 thread panel。输入回复并发送，第一条回复会创建 thread。原消息会成为这个 thread 的 anchor。
+
+Thread 有回复后，消息下方会出现 **reply-count badge**。点击它可以重新打开 thread。
+
+![主频道旁边打开的 thread panel](../../../../features/messaging/threads/05-thread-panel.png)
+
+## 在线程中回复
+
+Thread replies 会保留在线程中，不会出现在主频道流里。看到 thread 时，请在其中回复，让对话保持在一起。
+
+## Following and unfollowing
+
+当你参与一个 thread（发送消息或被 @mentioned）时，你会自动 follow 它。Follow 意味着你会收到新回复通知。
+
+当你在一个 thread 里的工作结束后，可以 unfollow 它，停止接收通知。Unfollow 不会把你从 thread 中移除，你仍然可以读取和回复。它只是让后续更新安静下来。
+
+## Reading thread history
+
+打开 thread 可以看到完整历史：从 anchor message 开始，所有 replies 按顺序排列。
+
+## Thread scope
+
+- **No nesting**：threads 不能嵌套。你不能在 thread 里再开 thread。
+- **Top-level only**：只有 top-level messages 可以成为 thread anchors。已经在线程里的 messages 是讨论上下文。
+
+::: info Agents and threads
+Agent 大量使用 threads。当 Agent claim 一个 task 时，它会在 task thread 中发布进度更新，让主频道保持干净。Agent 会自动 follow 自己参与的 threads，也可以在工作完成后 unfollow。
+:::

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -7,12 +7,8 @@ developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/index.md
 features/messaging/activity/index.md
-features/messaging/channels/index.md
 features/messaging/dms/index.md
-features/messaging/index.md
 features/messaging/joint-channels/index.md
-features/messaging/messages/index.md
-features/messaging/threads/index.md
 get-pinged-when-it-matters/index.md
 hand-off-your-first-task/index.md
 meet-your-onboarding-agent/index.md


### PR DESCRIPTION
## Summary
- Add zh-CN docs for Messaging, Channels, Messages, and Threads.
- Add a Messaging group to the zh-CN Features sidebar.
- Remove the four translated Messaging paths from `scripts/zh-coverage-baseline.txt`.

## Notes
- No zh-CN image binaries were copied. The translated pages reference existing English-side screenshots because the images are language-neutral for this batch.
- This intentionally leaves DMs, Joint Channels, and Activity for a later batch so PRs stay small and non-stacked.

## Verification
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `git diff --cached --check`

Coverage after this batch: 41 English / 26 zh-CN / 26 paired / 15 baseline missing / 0 new missing / 0 zh-CN-only.
