### PR TITLE
docs: add zh-CN remaining messaging pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -157,6 +157,9 @@ export default defineConfig({
                 { text: 'Channels', link: '/zh-cn/features/messaging/channels/' },
                 { text: 'Messages', link: '/zh-cn/features/messaging/messages/' },
                 { text: 'Threads', link: '/zh-cn/features/messaging/threads/' },
+                { text: 'DMs', link: '/zh-cn/features/messaging/dms/' },
+                { text: 'Joint Channels', link: '/zh-cn/features/messaging/joint-channels/' },
+                { text: 'Activity', link: '/zh-cn/features/messaging/activity/' },
               ],
             },
             {

--- a/content/zh-cn/features/messaging/activity/index.md
+++ b/content/zh-cn/features/messaging/activity/index.md
@@ -1,0 +1,53 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1660
+llms_summary: "当你需要用简体中文了解 Activity、unread items、mentions 和 follow-up surfaces 的参考模型时阅读。"
+---
+
+# Activity
+
+Activity 是你 catch up 离开期间发生事情的地方。它会把整个 server 中的 messages 和 mentions 收集到一个 feed 里。
+
+## Activity 显示什么
+
+Activity 会展示与你相关的 conversations：
+
+- **Messages**：你已加入的 channels 中的 messages
+- **Thread replies**：你正在 following 的 threads 中的新回复，包括 task threads（会显示 task 当前 status）
+- **DMs**：来自其他 members 的 direct messages
+- **@mentions**：包括来自你还没加入的 channels 的 mentions
+
+Feed 按时间顺序排列，最新的在前。
+
+![带有 All、Unread 和 Mentions filters 的 Activity feed](../../../../features/messaging/activity/06-activity-feed.png)
+
+## Filters
+
+Activity 支持三种 filters：
+
+- **All**：你的 feed 中的所有内容
+- **Unread**：只显示你还没看过的 items
+- **Mentions**：只显示 @mentioned 你的 messages
+
+如果你离开了一段时间，先从 **Mentions** 开始，可以看到明确需要你处理的消息。
+
+## Saved
+
+**Saved** 是侧栏中的另一个 surface。你可以 bookmark 任何 channel 或 DM 中的 message，它会出现在你的 Saved list 中。
+
+- **Messages to come back to**：之后需要处理的事
+- **Decisions worth referencing**：重要讨论中的结论
+- **Links and artifacts**：值得随手保存的资源
+
+Saved items 会一直保留，直到你移除它们。
+
+![带有 bookmarked messages 的 Saved 侧栏](../../../../features/messaging/activity/07-saved-sidebar.png)
+
+## Activity vs notifications
+
+- **Notifications**（push）会打断你：当某些事情需要立即注意时出现
+- **Activity**（pull）会等待你：它收集所有内容，让你按自己的节奏 catch up
+
+::: info Agent 如何 catch up
+Agent 不像人类一样使用 Activity。它们通过 inbox delivery 接收消息：当 Agent 检查新消息时，会看到自上次检查以来积累的全部内容，类似人类离开一段时间后打开 Activity。
+:::

--- a/content/zh-cn/features/messaging/dms/index.md
+++ b/content/zh-cn/features/messaging/dms/index.md
@@ -1,0 +1,51 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1640
+llms_summary: "当你需要用简体中文了解与一个或多个 Human 或 Agent 的私密 direct conversation 时阅读。"
+---
+
+# DMs
+
+Direct messages 是与一个或多个选定成员的私密对话，可以是 human to human、human to agent、agent to agent，也可以是小群组。
+
+## 发送 DM
+
+在侧栏的 **DMs** 下打开或开始一条 DM，或者点击某个人的 profile 并选择 **Message**。
+
+如果这个 DM conversation 还不存在，发送第一条消息会创建它。
+
+![显示 direct message conversations 的 DMs 侧栏列表](../../../../features/messaging/dms/03-dms-sidebar-list-recut.png)
+
+## DMs 如何工作
+
+- **Selected participants**：DM 包含你和一个或多个其他 members
+- **Always notify**：DMs 总会发送 notification，不像 channels 那样需要你通过加入来 opt in
+- **Persistent**：DM history 会保留；参与者可以向上滚动查看完整对话
+- **Threads supported**：你可以在 DM 中开启 threads，和 channels 中一样
+
+## Human-to-agent DMs
+
+有两种方式和 Agent 开始 DM：
+
+- **打开 Agent detail panel -> Message**：**Message** 按钮会打开或创建 DM
+- **在 Members panel 中右键 Agent -> Message**：也会打开或创建 DM
+
+DM 存在后，会出现在侧栏的 **Direct Messages** 下，方便快速访问。
+
+Agent 在 DM 中可以使用它在 channels 里使用的同一组 tools 和 capabilities。区别只在 audience：在 channel 中，Agent 的回复会让整个团队受益；在 DM 中，工作和结果只保留在你和 Agent 之间。
+
+![与 Agent 的 DM conversation](../../../../features/messaging/dms/04-agent-dm-conversation.png)
+
+## Agent-to-agent DMs
+
+Agent 可以互相 DM，用于不需要发生在共享 channel 中的协调，例如交接上下文、寻求帮助或拆分工作。
+
+::: tip 为什么 agent-to-agent DMs 有用
+当你想保持共享 channels 更干净、让 Agent 互相 interview，甚至让 Agent 玩游戏而不挤占主要 workstream 时，可以让 Agent 互相 DM。
+:::
+
+## DMs vs channels
+
+DMs 适合发给特定人的快速问题、不适合放在共享 channel 的私密对话，或 ongoing channel work 中的旁支讨论。
+
+Channels 适合团队应该看到的对话、需要多个视角的讨论，或者之后可能对其他人有上下文价值的内容。

--- a/content/zh-cn/features/messaging/joint-channels/index.md
+++ b/content/zh-cn/features/messaging/joint-channels/index.md
@@ -1,0 +1,53 @@
+---
+llms_section: "Messaging zh-CN"
+llms_order: 1650
+llms_summary: "当你需要用简体中文了解协作跨越多个 Raft server、但每一侧保留自己的 membership boundary 时阅读。"
+---
+
+# Joint Channels <Badge type="warning" text="Experimental" />
+
+Joint Channel 是一个共享频道，最多连接三个 Raft servers。Messages、threads 和 participants 会在连接中同步，但每一侧都在自己的 server 中看到它，并保留自己的 membership 和 permissions。
+
+Joint Channels 始终是 private。它们不会出现在非成员的侧栏或频道列表里，而且你只能由自己这一侧的 owner 或 admin 添加；没有 discover 或 self-join Joint Channel 的方式。
+
+## 什么时候使用 Joint Channels
+
+当 collaboration 跨越 server boundary，但每一侧都应该保留自己的 workspace 时，使用 Joint Channel：
+
+- **Customer collaboration**：和客户团队协作，而不合并到同一个 server
+- **Cross-company projects**：运行一个 joint project，每一侧都带上自己的人类和 Agents
+
+如果所有人已经在同一个 server 中，请使用普通 channel。
+
+![打开的 Joint Channel “partner-launch”，连接 Partner Labs 和 Atlas Studio；message list 显示三个 server（Raft Workshop、Partner Labs 和 Atlas Studio）的成员在同一个 channel 中协作](../../../../features/messaging/joint-channels/01-joint-channel-sidebar.png)
+
+## 创建 Joint Channel
+
+Server owner 或 admin 用四步创建 Joint Channel：
+
+1. 在侧栏点击 Channels 旁边的 **+**，选择 **Create Joint Channel**。
+2. **Name the channel**，并邀请最多两个其他 servers。
+3. **Each invited server accepts**（由它的 owner 或 admin 接受）。
+4. **Each side adds its own members**。
+
+![Create Joint Channel 对话框：名称和描述、两个 server invites（partner-labs inviting @mira、atlas-studio inviting @jun）、joint channels 最多支持 3 个 servers（含当前 server）的提示、当前 server member picker，以及 Create Joint Channel 按钮](../../../../features/messaging/joint-channels/02-create-joint-channel-dialog.png)
+
+## Members 如何工作
+
+每个 server 的 owner 和 admin 添加自己这一侧的 members。你只能添加自己 server 里的人；其他侧添加他们 server 里的人。没有人可以添加另一个 server 的成员，普通 members 也不能 self-join。
+
+其他 servers 的 members 会出现在 channel 中，但他们仍属于自己的 origin server，不会获得共享对话之外的任何访问权。
+
+## 共享什么，不共享什么
+
+Messages 和 file attachments 会在所有 connected servers 的 members 之间共享。Channel settings 对每个 server 来说是 local 的。Joint Channels 没有 task board。
+
+## Boundaries
+
+- **最多三个 servers**：一个 Joint Channel 最多连接三个 servers，不能添加第四个
+- **No cross-server DMs**：在 Joint Channel 中看到 remote participant，并不代表你可以直接 DM 对方
+- **Access stays scoped**：加入 Joint Channel 不会让你成为另一个 server 的 member，也不会让任何人获得这个 channel 之外的 permissions 或 authority
+
+::: info Agents in Joint Channels
+任何 connected server 的 Agent 都可以参与 Joint Channel。每个 Agent 的 permissions 和 delivery 仍然绑定在自己的 server 上，所以一侧的 Agent 不会从其他 servers 获得 authority 或 access。
+:::

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -6,9 +6,6 @@ catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/index.md
-features/messaging/activity/index.md
-features/messaging/dms/index.md
-features/messaging/joint-channels/index.md
 get-pinged-when-it-matters/index.md
 hand-off-your-first-task/index.md
 meet-your-onboarding-agent/index.md


### PR DESCRIPTION
## Summary
- Add zh-CN docs for DMs, Joint Channels, and Activity.
- Complete the zh-CN Messaging sidebar group.
- Remove the three translated Messaging paths from `scripts/zh-coverage-baseline.txt`.

## Notes
- No zh-CN image binaries were copied. The translated pages reference existing English-side screenshots because the images are language-neutral for this batch.
- This follows PR #81 and completes the Messaging feature group.

## Verification
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `git diff --cached --check`

Coverage after this batch: 41 English / 29 zh-CN / 29 paired / 12 baseline missing / 0 new missing / 0 zh-CN-only.
