### PR TITLE
docs: add zh-CN first-run journey pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -118,6 +118,9 @@ export default defineConfig({
               items: [
                 { text: 'Raft Docs', link: '/zh-cn/' },
                 { text: '欢迎使用 Raft', link: '/zh-cn/welcome/' },
+                { text: '认识你的 Onboarding Agent', link: '/zh-cn/meet-your-onboarding-agent/' },
+                { text: '交接你的第一个任务', link: '/zh-cn/hand-off-your-first-task/' },
+                { text: '邀请你的队友', link: '/zh-cn/bring-in-your-teammates/' },
               ],
             },
           ],

--- a/content/zh-cn/bring-in-your-teammates/index.md
+++ b/content/zh-cn/bring-in-your-teammates/index.md
@@ -1,0 +1,49 @@
+---
+title: 邀请你的队友
+description: 邀请人类队友进入 Raft server，并和同一批 Agent、频道和 tasks 一起工作。
+llms_section: "Start here zh-CN"
+llms_order: 1050
+llms_summary: "当你需要用简体中文了解如何邀请人类队友，并让他们和 Agent 在同一个 Raft server 中协作时阅读。"
+---
+
+# 邀请你的队友
+
+到目前为止，你的 raft 里有你和你的 Agent。现在该让团队里的其他人进来了。
+
+Raft 把两种队友放在同一个房间里。人类带来判断和方向，Agent 在中间承接工作。你目前设置好的东西，也就是频道、tasks 和 Agent，本来就是共享基础设施；邀请队友只是把门打开。
+
+更想看视频？这里是 walkthrough：
+
+<div class="video-embed" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.75rem 0; border-radius: 10px;">
+  <iframe
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"
+    src="https://www.youtube-nocookie.com/embed/eUE38tWBh2Y"
+    title="Raft Tutorial: Bring in your teammates"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
+## 邀请你的队友
+
+进入 **Settings → Invites**，用 email 发出邀请。Raft 会生成 invite link；你的队友接受后就会进入这个 server。进入后，你可以在每个频道的 member panel 里点击 **Add Members**，把他们加入对应频道。
+
+他们会出现在 member list 里，并能看到你添加他们进入的频道。
+
+## 他们也会和你的 Agent 一起工作
+
+你的 Agent 不是私人的助手，而是 server 成员。你的队友可以 @mention 你一直在合作的同一个 Agent，把 task 交给它，也可以在频道里阅读它的历史。一个 Agent，整个团队一起用。
+
+这也会带来正向循环：Agent 对项目积累的知识可以服务所有人，任何队友的纠正也会让它对所有人更有用。
+
+## 工作会自然拆开
+
+人类在工作发生的地方对话：频道承载项目和方向，线程承载具体讨论，DM 承载旁支交流。Tasks 有 owner 和 status，所以两个人不会同时接同一件事。Agent 完成工作后，任何队友都可以 review，通常就是那个设定方向的人。
+
+当一位队友 review 并关闭了你没有碰过的 task，这个协作方式就会变得很直观。
+
+## 刚才发生了什么
+
+你的 raft 现在承载的是一个团队：人类掌舵，Agent 承接执行，所有人共处一个房间。继续加入更多人或更多 Agent，Raft 都能承载。

--- a/content/zh-cn/hand-off-your-first-task/index.md
+++ b/content/zh-cn/hand-off-your-first-task/index.md
@@ -1,0 +1,85 @@
+---
+title: 交接你的第一个任务
+description: 把第一件真实工作交给 Raft Agent，并通过 task thread 跟进、review 和关闭。
+llms_section: "Start here zh-CN"
+llms_order: 1040
+llms_summary: "当你需要用简体中文了解如何把第一件真实任务交给 Agent，并完成跟进、review 和关闭时阅读。"
+---
+
+# 交接你的第一个任务
+
+你已经有了 server、连接好的 Computer，以及一个会回应你的 Agent。现在该看它真正能做什么了：把一件真实工作交给它，看它带着结果回来。
+
+更想看视频？这里是 walkthrough：
+
+<div class="video-embed" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.75rem 0; border-radius: 10px;">
+  <iframe
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"
+    src="https://www.youtube-nocookie.com/embed/Pqrb7eKqX_I"
+    title="Raft Tutorial: Hand off your first task"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
+## Step 1: 描述工作
+
+选一件真实但不太大的事情：一个你平时会自己研究的问题、一份需要起草的文件，或一段你想让人解释的代码。
+
+然后像和同事说话一样，在频道里告诉你的 Agent。你不需要写完美 prompt。说清楚你想要什么、为什么需要它，然后把怎么做交给 Agent。如果有不清楚的地方，它会问你。
+
+一个开发者想梳理新代码库：
+
+```text
+Read through our codebase and give me a map of the main modules - what each one does, how they connect, and where the entry points are. Flag anything that looks like dead code or unused dependencies.
+```
+
+一个数据分析师在检查获客渠道：
+
+```text
+Pull our signups from the last 30 days, break them down by acquisition channel, and show me which ones are converting to weekly active users. Include the raw numbers and the conversion rate for each.
+```
+
+一个投资研究员在准备通话：
+
+```text
+Research Shopify's last two quarterly earnings calls. Summarize what management emphasized, where analysts pushed back, and any changes to forward guidance. Link to the primary sources.
+```
+
+![Sending several messages in the channel](../../hand-off-your-first-task/06-stacked-messages.png)
+
+你可以继续补充上下文、链接和新的想法。Agent 读取频道时，会按顺序拿到你发过的所有内容。
+
+## Step 2: 把它变成 task
+
+一条请求工作的消息可以变成 task：它会得到编号、状态和 owner，这样工作会被跟踪，而不是从对话里滚走。右键点击消息（移动端长按），选择 **Convert to Task**。这个 task 一开始没有人 claim；你的 Agent 会 claim 它并开始工作。
+
+::: info Task statuses
+Task 会经历四个状态：**todo** → **in progress** → **in review** → **done**。Agent 工作时会更新状态；“in review” 表示它正在等待队友 review。
+:::
+
+Task 会显示 Agent 是 owner，状态也会切到 in progress。
+
+## Step 3: 让它运行
+
+这一段需要练习：离开一下。Agent 会在 task thread 里发布进度，它会在你的 Computer 开着的时候继续工作，不管你有没有一直看着。去倒杯咖啡，十分钟后再回来。
+
+![Agent posting progress in the task thread](../../hand-off-your-first-task/07-agent-progress-thread.png)
+
+如果 Agent 在完成前停住了，或者结果不是你想要的，就在线程里回复。告诉它哪里不对、缺了什么。它会带着你新的上下文，从停下的地方继续。
+
+你回来时，线程里已经有了你没亲眼看到的进展。
+
+## Step 4: Review and close
+
+Agent 完成后，会把 task 设为 in review，并发布结果。现在轮到你：像读同事交付的工作一样读它。如果结果没问题，就确认并把 task 标记为 done。如果不对，就在线程里说清楚哪里不对，Agent 会继续处理。
+
+这些反馈不是一次性的。你的 Agent 会记住它，下一次任务会更接近你想要的样子。
+
+Task 被标记为 done，而那件工作不是你亲手做的。
+
+## 刚才发生了什么
+
+你刚刚跑完了 Raft 中所有工作的基本循环：描述、交接、让它运行、review。更大的工作，比如多个 Agent、完整项目、长期任务，本质上都是这个循环的放大版。

--- a/content/zh-cn/meet-your-onboarding-agent/index.md
+++ b/content/zh-cn/meet-your-onboarding-agent/index.md
@@ -1,0 +1,113 @@
+---
+title: 认识你的 Onboarding Agent
+description: 创建你的第一个 Raft server，连接一台 Computer，并创建 Cindy 作为 onboarding agent。
+llms_section: "Start here zh-CN"
+llms_order: 1030
+llms_summary: "当你需要用简体中文完成第一次设置：创建 server、连接 Computer，并创建 Cindy 这个 onboarding agent 时阅读。"
+---
+
+# 认识你的 Onboarding Agent
+
+接下来的十分钟里，你会拥有自己的 server、一台已连接的 Computer，以及你的第一个 Agent：Cindy，onboarding agent。她是你创建的第一位队友。她进房间之后，后面的设置就不再是你一个人完成。
+
+更想看视频？这里是 walkthrough：
+
+<div class="video-embed" style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; margin: 1.75rem 0; border-radius: 10px;">
+  <iframe
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"
+    src="https://www.youtube-nocookie.com/embed/uEIzqRH7pVE"
+    title="Raft Tutorial: Meet your Onboarding Agent"
+    loading="lazy"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
+## Step 1: 创建你的 server
+
+Server 是你的人员、Agent、频道和 Computer 所在的工作空间。Raft 里的所有事情都发生在 server 里，所以它是第一步。
+
+在 **Create server** 页面，填写 server name。URL slug 会根据名称自动生成；如果你想换一个地址，也可以手动修改。
+
+![Create server screen](../../meet-your-onboarding-agent/01-create-server.png)
+
+你会进入 **#onboarding-owner**，这是你的私有 onboarding 空间。你是 owner。现在这里还很安静，但马上就会热闹起来。
+
+## Step 2: 连接一台 Computer
+
+这是设置 server 的两个步骤之一。Computer 是 Agent 实际运行的机器，靠近你的真实文件和工具；你的 server 至少需要一台在线 Computer。
+
+在 **Connect a computer** 步骤，Raft 会显示这个 server 对应的安装命令和设置命令。复制这些命令，在你的 terminal 里运行。在 macOS 和 Linux 上，这会安装 Raft Computer，并开始为这个 server 做设置。
+
+如果设置过程在浏览器里打开 device login 页面，请按需登录并批准这次登录，然后回到 terminal 等待设置完成。请求批准后，设置面板会更新，显示这台机器已连接。
+
+::: info Windows 设置
+如果设置面板显示的是 Windows 命令，它会在 WSL（Windows Subsystem for Linux）里运行。Raft 目前还没有原生 Windows app。请保持这个 terminal 窗口打开；详情见 [Computers](/zh-cn/features/server/computers/#连接-computer)。
+:::
+
+第一次用 terminal？先看下面的 [如何打开 terminal](#appendix-如何打开-terminal)，然后回到这里继续。
+
+机器连接后，Raft 会在同一台 Computer 上检查可用的 runtime，也就是 Agent 运行所用的 coding agent，并列出检测到的选项。下一步你会选择 Cindy 使用哪个 runtime。如果还没有检测到任何 runtime，请先安装一个 runtime，或接入你自己的 API key，再继续。见 [安装 runtime](#appendix-安装-runtime)。
+
+![Connect computer step, with the setup commands and detected runtimes listed](../../meet-your-onboarding-agent/03-computer-connected.png)
+
+::: tip 重新连接 Computer
+如果 Computer 后面显示为 offline，在那台机器上重启 Raft Computer 即可重新连接，不需要添加一台新的 Computer。
+:::
+
+## Step 3: 认识 Cindy
+
+这是第二个步骤，也是房间真正活起来的那一步。
+
+Cindy 是熟悉 Raft 的 onboarding agent。作为你的第一个 Agent，她会帮助设置 server，并把你的团队带进来。你可以给她写一段简短描述，然后设置她运行的 **Runtime**，也就是刚才连接的 Computer 上检测到的 runtime，再选择 provider 和 model。
+
+::: info Runtimes
+Runtime 是你已经在用的 coding agent，也是你现有 AI 订阅接入 Raft 的地方。Raft 推荐的 runtime 是 **Claude Code** 和 **Codex CLI**；同时也支持 Antigravity CLI、Copilot CLI、Cursor CLI、Gemini CLI、Kimi Code、OpenCode 和 Pi。你也可以不安装 runtime，而是接入自己的 API key。请选择刚连接的 Computer 上已经安装的 runtime；如果还没有，见下面的 [安装 runtime](#appendix-安装-runtime)。
+:::
+
+![Meet Cindy, with the runtime, provider, and model pickers](../../meet-your-onboarding-agent/04-create-onboarding-agent.png)
+
+Cindy 会在 **#onboarding-owner** 等你。她会介绍自己，主动帮你把 Agent 组织成一个能工作的团队，并在线程里放一个简短的 “team mode” 示例。跟她打个招呼，她会回复你。
+
+![Cindy's welcome in #onboarding-owner](../../meet-your-onboarding-agent/05-oa-first-hello.png)
+
+从这里开始，Cindy 会带你完成后续设置。以后你对 Raft 有任何问题，也都可以去找她。哪里卡住了，直接问她。
+
+## 刚才发生了什么
+
+你现在有了一个房间、一台机器和一位队友。房间承载对话，机器执行工作，Agent 是那个不会下线的成员。Raft 后面的所有能力，都建立在这三件事上。
+
+## Appendix: 如何打开 terminal
+
+Terminal 是一个文本窗口，你可以把 **Connect a computer** 步骤里的命令粘进去运行。如果你从没打开过 terminal，可以按下面做。
+
+**在 Mac 上**
+
+1. 按 **⌘ + Space** 打开 Spotlight，输入 **Terminal**，然后按 **Return**。（也可以打开 **Finder → Applications → Utilities → Terminal**。）
+2. 点击 terminal 窗口，用 **⌘ + V** 粘贴命令，然后按 **Return**。
+
+如果需要 Apple 的分步说明，见 [Open or quit Terminal on Mac](https://support.apple.com/guide/terminal/open-or-quit-terminal-apd5265185d-f365-44cb-8b09-71a064a42125/mac)。
+
+**在 Windows 上**
+
+1. 按 **Windows key**，输入 **Terminal**（Windows 11）或 **PowerShell**（Windows 10），然后按 **Enter**。
+2. 点击窗口，用 **Ctrl + V** 粘贴命令，然后按 **Enter**。
+
+如果需要 Microsoft 的分步说明，见 [Starting Windows PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/starting-windows-powershell)。
+
+命令会自己继续运行。完成后，设置面板会显示 Computer online；回到 Step 2 继续即可。
+
+## Appendix: 安装 runtime
+
+下面这些都可以和 Raft 一起使用。选一个，按它的安装指南操作，然后回到 Step 3。
+
+- [Claude Code](https://code.claude.com/docs)
+- [Codex CLI](https://developers.openai.com/codex/cli)
+- [Antigravity CLI](https://antigravity.google/docs/cli-install)
+- [Copilot CLI](https://github.com/github/copilot-cli)
+- [Cursor CLI](https://cursor.com/docs/cli/installation)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [Kimi Code](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html)
+- [OpenCode](https://opencode.ai)
+- [Pi](https://pi.dev)

--- a/content/zh-cn/welcome/index.md
+++ b/content/zh-cn/welcome/index.md
@@ -18,13 +18,13 @@ Raft 是人类和 AI Agent 一起工作的地方。
 
 ## 开始使用
 
-**[认识你的 Onboarding Agent](/meet-your-onboarding-agent/)**
+**[认识你的 Onboarding Agent](/zh-cn/meet-your-onboarding-agent/)**
 创建服务器，连接一台 Computer，并认识你团队里的第一个 Agent。
 
-**[交接你的第一个任务](/hand-off-your-first-task/)**
+**[交接你的第一个任务](/zh-cn/hand-off-your-first-task/)**
 把真实工作交给 Agent，看它带着结果回来。
 
-**[邀请你的队友](/bring-in-your-teammates/)**
+**[邀请你的队友](/zh-cn/bring-in-your-teammates/)**
 邀请人类进入同一个房间，和 Agent 并肩工作。
 
 **[把 Raft 安装到手机上](/raft-on-every-device/)**

--- a/scripts/zh-coverage-baseline.txt
+++ b/scripts/zh-coverage-baseline.txt
@@ -1,14 +1,11 @@
 # Existing English pages without zh-CN at the baseline (b0bd2eb).
 # Remove an entry when its translation lands; new asymmetry still fails CI.
-bring-in-your-teammates/index.md
 build-your-agent-team/index.md
 catch-up-in-one-place/index.md
 developers/best-practices/service-cli-migration/index.md
 divide-the-work/index.md
 features/index.md
 get-pinged-when-it-matters/index.md
-hand-off-your-first-task/index.md
-meet-your-onboarding-agent/index.md
 raft-on-every-device/index.md
 search-your-raft/index.md
 tutorials/investing-research-team/index.md


### PR DESCRIPTION
## Summary
- Add zh-CN translations for the first-run journey pages: onboarding agent, first task handoff, and teammate invites.
- Wire the new pages into the zh-CN Start sidebar and keep the zh-CN welcome links inside the zh-CN route.
- Remove exactly those three pages from the zh-CN coverage baseline.

## Verification
- pnpm build
- pnpm check:agent-artifacts
- pnpm check:zh-coverage -- --check
- git diff --check
- git diff --cached --check

## Exact binding
- B: 7e677e5e8005c19cfc2b579b9374d050dffb619d
- H: c3cf931305dee544aeb25fb2bb2802632908434c
- T: e9fbfa9bafb8ba14d92c9b314642c71d0617e9e4

Coverage after this batch: 41 English / 32 zh-CN / 32 paired / 9 baseline missing / 0 new missing / 0 zh-CN-only.