### PR TITLE
Replace service CLI migration zh-CN translation

### DIFF
--- a/content/zh-cn/developers/best-practices/service-cli-migration/index.md
+++ b/content/zh-cn/developers/best-practices/service-cli-migration/index.md
@@ -2,23 +2,23 @@
 title: 将 Agent 操作迁移到 Service CLI
 llms_section: "Developers zh-CN"
 llms_order: 1910
-llms_summary: "当 Raft App 的 manifest actions 已经超出 manifest 适合承载的范围，需要把新能力迁移到自己的认证 service CLI，同时不破坏现有调用方时阅读。"
+llms_summary: "当 Raft App 的 manifest 操作已经超出 manifest 适合承载的边界，需要把新能力迁移到自带认证的 Service CLI，同时不破坏既有调用方时阅读。"
 ---
 
 # 将 Agent 操作迁移到 Service CLI
 
-Manifest actions 是很好的发现和 bootstrap surface。随着 app 成长，专用 service CLI 通常会成为完整命令集更合适的承载位置：它可以提供更丰富的 workflows、uploads、streaming output、本地文件和正常的 shell 组合，而不用把 Raft manifest 变成第二套 SDK。
+manifest（清单）操作是很好的发现和引导入口。随着 App 成长，专用的 Service CLI 往往会成为承载完整命令集更合适的地方：它能提供更丰富的工作流、上传、流式输出、本地文件，以及常规的 shell 组合方式，而不必把 Raft 的 manifest 变成第二套 SDK。
 
-当你已经有可用的 agent actions，并想把未来能力迁移到自己的 CLI，同时不破坏现有调用方时，使用这份指南。
+当你已经有一组能正常工作的 Agent 操作，又不想破坏既有调用方，想把未来的能力放进自己的 CLI 时，请使用这份指南。
 
 ## 目标模型
 
 保持职责分离：
 
-- **Raft** 证明涉及哪个 Agent、app 和 server，并交付短期、一次性的 login grant。
-- **你的 service** 把该 grant 换成自己的 access token 和 refresh token，执行自己的权限规则，并拥有 token revocation。
-- **你的 CLI** 把 service session 存到当前 Agent 隔离的 Raft home，并自动刷新。
-- **现有 manifest actions** 在兼容窗口内继续可调用，并把 Agent 引向 migration help。
+- **Raft**：负责证明涉及的是哪个 Agent、哪个 App、哪个服务器，并交付一个短期、一次性的登录 grant。
+- **你的服务**：用这份 grant 换取自己的 access token 和 refresh token，执行自己的权限规则，并负责 token 撤销。
+- **你的 CLI**：把 service session 存进当前 Agent 隔离的 Raft 主目录，并自动刷新。
+- **既有 manifest 操作**：在兼容窗口内仍然可调用，并把 Agent 引向 migration help。
 
 ```text
 service-cli login
@@ -31,101 +31,101 @@ service-cli login
   → run normal service-cli commands with automatic refresh
 ```
 
-最终的 service tokens 和 proof verifier 不会经过 Raft 或 Raft daemon。
+最终的 service token 和 proof verifier 不会经过 Raft，也不会经过 Raft daemon。
 
-## 保持三种登录 surface 独立
+## 保持三种登录方式相互独立
 
-不要让 agent login 静默改变 human 或 CI authentication。
+不要让 Agent 登录静默地改变人类或 CI 的认证方式。
 
-| Surface | 推荐认证方式 |
+| 登录方式 | 推荐的认证方式 |
 | --- | --- |
-| Human | Browser login 和 human-owned local session |
-| CI | 显式、范围收窄的 deploy 或 automation token |
-| Raft agent | 一次性 Raft grant，然后在 Agent-specific store 里保存 service access + refresh tokens |
+| 人类 | 浏览器登录 + 人类拥有的本地 session |
+| CI | 一个显式、范围收窄的部署或自动化 token |
+| Raft Agent | 一次性 Raft grant，然后把 service access token 和 refresh token 存进该 Agent 专属的存储 |
 
-Agent-environment detection 必须 fail closed。要求 daemon 提供的完整 contract，包括 Agent identity、server identity、`SLOCK_HOME` 和 Raft CLI transport。部分环境是错误，不是回退到 host user's home 或 ambient credentials 的许可。在当前 daemon contract 中，三个 Agent 标记是 `SLOCK_CLI_TRANSPORT_DIR`、`SLOCK_HOME` 和 `SLOCK_AGENT_ID`；`SLOCK_*` 是保留下来的旧 Slock-to-Raft 前缀，所以通用实现应把它们视为 daemon 提供的 agent-home 和 transport markers，而不是某个 app 自己的约定。
+Agent 环境检测必须 fail closed。它要求 daemon 提供完整的契约，包括 Agent identity、server identity、`SLOCK_HOME` 和 Raft CLI transport。环境不完整是错误，而不是允许回退到 host 用户 home 或 ambient credentials 的许可。在当前 daemon 契约中，三个 Agent 标记是 `SLOCK_CLI_TRANSPORT_DIR`、`SLOCK_HOME` 和 `SLOCK_AGENT_ID`；`SLOCK_*` 是旧 Slock-to-Raft 前缀，为兼容而保留，所以通用实现应把它们视为 daemon 提供的 Agent home 和 transport 标记，而不是某个 App 自己的约定。
 
-## 使用 proof-bound 的一次性 grant
+## 使用受 proof 约束的一次性 grant
 
-CLI 应创建高熵的本地 verifier，并只把 challenge 通过 manifest action 发出去。返回的 grant 应绑定：
+CLI 应生成一个高熵的本地 verifier，并且只把 challenge 通过 manifest 操作发出去。得到的 grant 应绑定：
 
 - 一个 Agent
-- 一个 Raft server
-- 一个 app 或 service
+- 一个 Raft 服务器
+- 一个 App 或 service
 - proof challenge
-- 短 expiration time
-- 一次 atomic exchange
+- 一个很短的过期时间
+- 一次原子交换
 
-Service 在签发 grant 时记录认证后的 identity 和 challenge。Exchange 时，它验证本地 verifier，原子性消费 grant，并从已保存的 identity 创建 service session。CLI 不允许在 exchange request 里自己声明 Agent 或 server identity。
+service 在签发 grant 时，会记录下经过认证的 identity 和 challenge。在交换时，它校验本地 verifier、原子性地消费掉这份 grant，并用保存下来的 identity 创建 service session。CLI 不允许在 exchange 请求里自行声明自己的 Agent 或 server identity。
 
-把 grants、verifiers、access tokens 和 refresh tokens 都视为 credential material：永远不要把它们放进 chat、logs、error text、action descriptions、telemetry 或 command output。
+把 grant、verifier、access token 和 refresh token 都当作凭据材料（credential material）：永远不要把它们放进聊天、日志、错误文本、操作描述、遥测或命令输出里。
 
-## 安全地存储和刷新
+## 安全地存储与刷新
 
-把 service session 存在 Agent-specific path 下：
+把 service session 存在 Agent 专属路径下：
 
 ```text
 $SLOCK_HOME/agents/$SLOCK_AGENT_ID/integrations/<service>/auth.json
 ```
 
-Service slug 必须不能逃出该目录。目录用 `0700` 创建，文件用 `0600`，在同一目录写 temporary file，再 atomic rename 覆盖旧 session。写入失败必须保留最后一个 known-good session。
+service slug 必须无法逃离该目录。目录用 `0700` 创建，文件用 `0600`，在同一目录写临时文件，再通过原子重命名覆盖旧 session。写入失败必须保留上一次已知良好的 session。
 
-这可以避免 Agent 之间意外共享。它不是抵御同一操作系统用户下恶意进程的隔离边界。如果需要更强边界，请使用 daemon-held credentials 或单独的 OS identities。
+这能避免 Agent 之间意外共享。它不是抵御以同一操作系统用户身份运行的恶意进程的隔离边界。如果需要更强的边界，请使用 daemon 持有的凭据或单独的操作系统身份。
 
-在 access expiry 前刷新，并轮换 refresh tokens。遇到 `401` 时，重新加载 store，协调并发命令只做一次 refresh，然后最多重试一次 request。Expired、revoked、reused 或 invalid refresh token 必须 fail closed，并告诉调用方重新运行 login command。
+在 access 过期前刷新，并轮换 refresh token。遇到 `401` 时，重新加载存储，让并发命令协调成只做一次 refresh，然后最多重试该请求一次。过期、被撤销、被复用或无效的 refresh token 必须 fail closed，并告诉调用方重新运行 login 命令。
 
-Token endpoints 需要比普通 API requests 更严格的 network behavior：
+token endpoint 需要比普通 API 请求更严格的网络行为：
 
-- 拒绝 redirects，而不是继续转发带 credential 的 request bodies
-- 限制 response size
-- timeout 覆盖 headers、body reading、parsing 和 persistence 的全过程
-- 拒绝 unknown response fields 和已经过期的 sessions
-- 让 lock ownership 显式化；不要只因为时间过去了就 break a lock，因为 owner 可能仍然 alive
+- 拒绝重定向，而不是转发携带凭据的请求体
+- 限制响应体大小
+- 让超时覆盖请求头、读取响应体、解析与持久化的全过程
+- 拒绝未知的响应字段和已经过期的 session
+- 把 lock 归属显式化；不要只因为时间过去就破坏一把锁，因为 owner 可能仍然存活
 
-## 保留现有 action 调用方
+## 保留既有操作调用方
 
-不要因为 CLI 已经存在就移除可用的 actions。
+不要因为 CLI 存在就移除还能用的操作。
 
-1. 为 bootstrap flow 添加 `agent-login`。
-2. 添加一个 `migration-help` action，包含 installation、login、recovery 和 old-action-to-CLI mappings。
-3. 保持现有 action names 和 response contracts 稳定。
-4. 在 legacy action descriptions 前加简短 deprecation notice，指向 `migration-help`。
-5. 把新的 product capabilities 放进 service CLI。
+1. 为引导流程添加 `agent-login`。
+2. 添加一个 `migration-help` 操作，包含安装、登录、恢复，以及旧操作到 CLI 命令的映射。
+3. 保持既有操作名称和响应契约稳定。
+4. 在旧操作描述前加上简短、指向 `migration-help` 的弃用提示。
+5. 把新的产品能力放进 Service CLI。
 
-Manifest description 是 migration guidance 最安全的默认位置，因为 Agent 会在 discovery 期间看到它，而现有 action payload 保持不变。如果调用时也必须返回 warning，请先给 shared action schema 添加可选 warning metadata。不要把 human prose 注入已经稳定的 machine response body。
+manifest 描述是安放迁移引导最安全的默认位置，因为 Agent 会在发现阶段看到它，而既有操作 payload 保持不变。如果调用时也必须给调用方一条 warning，请先给共享的操作 schema 加上可选 warning metadata。不要把人类散文注入已经稳定的机器响应体。
 
 ## 分阶段发布，每个阶段都能独立回滚
 
-为每个阶段设置单独 gates：
+为每个阶段设置单独的 gate：
 
-1. Review generic login contract 和 threat model。
-2. Ship service grant、exchange、refresh、rotation 和 revocation support。
-3. Ship CLI login、agent-specific store、refresh 和 request integration。
-4. 在真实 Raft agent seat 里验证 login 和 token rotation。
-5. 发布 installable CLI，并验证 published package，而不只是 source tree。
-6. 只有 CLI path 可用后，才给 legacy actions 添加 deprecation guidance。
+1. 审查通用登录契约和威胁模型。
+2. 交付 service grant、exchange、refresh、rotation 和 revocation 支持。
+3. 交付 CLI 登录、Agent 专属存储、refresh 和请求集成。
+4. 在真实的 Raft Agent seat 里验证登录和 token rotation。
+5. 发布可安装的 CLI，并验证发布后的 package，而不只是 source tree。
+6. 只有在 CLI 路径可用之后，才给旧操作添加弃用引导。
 
-保留之前的 human login、CI tokens 和 legacy actions 作为 rollback paths。Source merge 不证明 service 已部署，部署也不证明用户能安装已修好的 CLI。
+保留之前的人类登录、CI token 和旧操作作为回滚路径。一次 source merge 并不能证明服务已经部署，一次部署也不能证明用户能装好修好的 CLI。
 
-## 验证 checklist
+## 验证清单
 
-Rollout 前，证明：
+上线前，证明：
 
-- grant expiration、one-time use、replay rejection 和 proof mismatch
-- captured grant 没有 verifier 就无法创建 session
-- stale 或 revoked refresh sessions 能通过 fresh login 恢复
-- access 和 refresh rotation、proactive refresh，以及一个受控的 `401` retry
-- 并发命令有 deterministic single-flight behavior
-- redirect rejection、bounded and slow response bodies，以及 closed response schemas
-- 不会从 Agent environment 回退到 host HOME、XDG 或 ambient tokens
-- human 和 CI login behavior 保持不变
-- read command、write/upload command 和 `whoami` 能在真实 Agent seat 里运行
-- published package 报告 expected version，并包含 reviewed behavior
+- grant 过期、一次性使用、重放拒绝和 proof 不匹配
+- 被截获的 grant 没有 verifier 就无法创建 session
+- 陈旧或已被撤销的 refresh session 能通过重新登录恢复
+- access 和 refresh 的 rotation、主动 refresh，以及一次受控的 `401` 重试
+- 并发命令有确定性的 single-flight 行为
+- 重定向拒绝、受限且缓慢的响应体，以及封闭的响应 schema
+- 不会从 Agent 环境回退到 host HOME、XDG 或 ambient token
+- 人类和 CI 的登录行为保持不变
+- read 命令、write/upload 命令和 `whoami` 能在真实 Agent seat 里工作
+- 发布后的 package 报告了预期版本，并包含经过审核的行为
 
-使用一个 version source：从 package 或 release manifest 推导 CLI 的 runtime `--version`，不要在 entry point 里 hard-code 第二份版本号。真正 publish 之前，跑完整 build、pack、version、dependency 和 `publish --dry-run` 路径。
+只用一个 version 来源：让 CLI 的运行时 `--version` 从 package 或 release manifest 推导，而不是在入口点硬编码第二份版本号。真正发布前，跑一遍完整的构建、打包、版本、依赖和 `publish --dry-run` 路径。
 
-## Hands 作为参考
+## 以 Hands 为参考
 
-[Hands](https://github.com/botiverse/hands) 使用这种模式做 compatibility migration：现有 Raft actions 继续可用，并在 discovery-time 提供 migration guidance；完整和未来的 surface 则放在 `hands` CLI。`agent-login` action bootstrap Agent-specific Hands session，`migration-help` 把 legacy actions 映射到 CLI commands。
+[Hands](https://github.com/botiverse/hands) 就是用这种模式做兼容迁移的：它的既有 Raft 操作继续可用，并在发现阶段提供迁移引导；完整和未来的 surface 则放在 `hands` CLI。`agent-login` 操作用来引导出一个 Agent 专属的 Hands session，`migration-help` 则把旧操作映射到 CLI 命令。
 
-把 Hands 当作 implementation reference，而不是 protocol definition。Service names、action counts、versions 和 product commands 都是 app-specific；上面的 identity、proof、storage、compatibility 和 verification boundaries 才是可复用的 contract。
+把 Hands 当作实现参考，而不是协议定义。service 名称、操作数量、版本和产品命令都是 App 自己定的；上面这些 identity、proof、storage、兼容和验证边界才是可复用的契约。


### PR DESCRIPTION
## Summary
- Replace the zh-CN `service-cli-migration` page with AngLee's full retranslation.
- Keep the existing page frontmatter structure and only touch this one zh-CN file.

## Review split
- Chinese quality: AngLee provided the full draft and marked the Chinese review PASS in task #82.
- Engineering/behavior gate before merge: Maggie to verify structure/behavior/checks/landing.

## Local checks
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `git diff --cached --check`
- Structure sanity: English and zh-CN both have 8 h2 headings, 4 fence markers, and 5 table rows.

Task: #proj-i18n task #82
