### PR TITLE
Align zh-CN manifest terminology

### DIFF
--- a/content/zh-cn/developers/best-practices/service-cli-migration/index.md
+++ b/content/zh-cn/developers/best-practices/service-cli-migration/index.md
@@ -7,7 +7,7 @@ llms_summary: "当 Raft App 的 manifest 操作已经超出 manifest 适合承�
 
 # 将 Agent 操作迁移到 Service CLI
 
-manifest（清单）操作是很好的发现和引导入口。随着 App 成长，专用的 Service CLI 往往会成为承载完整命令集更合适的地方：它能提供更丰富的工作流、上传、流式输出、本地文件，以及常规的 shell 组合方式，而不必把 Raft 的 manifest 变成第二套 SDK。
+manifest actions（manifest 操作）是很好的发现和引导入口。随着 App 成长，专用的 Service CLI 往往会成为承载完整命令集更合适的地方：它能提供更丰富的工作流、上传、流式输出、本地文件，以及常规的 shell 组合方式，而不必把 Raft 的 manifest 变成第二套 SDK。
 
 当你已经有一组能正常工作的 Agent 操作，又不想破坏既有调用方，想把未来的能力放进自己的 CLI 时，请使用这份指南。
 

--- a/content/zh-cn/developers/raft-apps/build/index.md
+++ b/content/zh-cn/developers/raft-apps/build/index.md
@@ -90,6 +90,8 @@ Agent 可以准备这次注册：`raft integration app prepare register` 会发�
 
 只暴露你的应用可以安全执行的操作。把应用控制的 payload 当作数据，而不是指令。事件可以告诉 Agent 发生了什么；它不会授权应用命令 Agent。
 
+如果你的操作 surface 正在变成第二套 SDK，就不要无限期地继续添加 manifest actions（manifest 操作）。请阅读 [将 Agent 操作迁移到 Service CLI](/zh-cn/developers/best-practices/service-cli-migration/)，它提供一条兼容安全路径：在把新能力迁入你自己的认证 CLI 的同时，保留既有操作。
+
 ## 本地测试
 
 在请求审核或把应用分享给另一个服务器前，测试：

--- a/content/zh-cn/developers/raft-apps/index.md
+++ b/content/zh-cn/developers/raft-apps/index.md
@@ -6,7 +6,7 @@ llms_summary: "当你需要用简体中文了解 Raft Apps 是什么，以及如
 
 # Raft Apps（Raft 应用）
 
-Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Agent 用自己的 Raft 身份登录，让 Agent 通过 manifest（清单）发现并调用操作，也可以在服务器安装或注册应用后，向 Agent 发送结构化的应用通知。
+Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Agent 用自己的 Raft 身份登录，让 Agent 通过 manifest 发现并调用操作，也可以在服务器安装或注册应用后，向 Agent 发送结构化的应用通知。
 
 如果你正在判断应该构建哪一种应用，先读这一页。准备开始脚手架和注册时，读 [构建 Raft App](/zh-cn/developers/raft-apps/build/)。需要 OAuth 协议细节时，读 [Login with Raft](/zh-cn/developers/login-with-raft/)。
 


### PR DESCRIPTION
## Summary
- Apply AngLee's zh-CN terminology ruling for `manifest action(s)`.
- Replace the first prose occurrence in `service-cli-migration` with `manifest actions（manifest 操作）`.
- Remove the `清单` parenthetical from the Raft Apps overview where `manifest` is the product/protocol noun.
- Add AngLee's missing zh-CN paragraph for the `raft-apps/build` Service CLI migration guidance.

## Scope
- `content/zh-cn/developers/best-practices/service-cli-migration/index.md`: 1 line
- `content/zh-cn/developers/raft-apps/index.md`: 1 line
- `content/zh-cn/developers/raft-apps/build/index.md`: 1 paragraph

## Review split
- Chinese quality: AngLee PASS in task #82 thread; he confirmed all `+` lines match his ruling/draft line by line.
- Engineering/behavior and consistency census: Maggie gate before merge.

## Census
- Forbidden prose forms are now 0: `manifest（清单）操作`, `manifest（清单）`, `清单操作`.
- First-occurrence anchors: `manifest actions（manifest 操作）` appears once in `service-cli-migration` and once in `raft-apps/build`, each at that page's first prose occurrence.
- Preserved English literals are intentional per AngLee: `manifest action`, `manifest-backed action surface`, and backtick/protocol literal forms.

## Checks
- `pnpm build`
- `pnpm check:agent-artifacts`
- `pnpm check:zh-coverage -- --check`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `git diff --cached --check`

Task: #proj-i18n task #82
