### PR TITLE
docs: native mobile download info block (en+zh)

### DIFF
--- a/content/raft-on-every-device/index.md
+++ b/content/raft-on-every-device/index.md
@@ -17,6 +17,10 @@ Open Raft on a machine you've never used and everything's exactly where you left
 
 ## Add it to your phone
 
+::: info Native mobile apps
+Prefer a native app? Get it at [app.raft.build/download](https://app.raft.build/download) — the Android installer and the iOS app (via TestFlight) are both there.
+:::
+
 On desktop, just use the website — there's nothing to install. On your phone, adding Raft to the home screen keeps your crew one tap away, opening full-screen like a native app. At a glance:
 
 - **iPhone / iPad (Safari):** Share → **Add to Home Screen**

--- a/content/zh-cn/raft-on-every-device/index.md
+++ b/content/zh-cn/raft-on-every-device/index.md
@@ -19,6 +19,10 @@ Raft 是 web app，可以在现代桌面和移动浏览器里运行。登录后�
 
 ## 加到手机上
 
+::: info 原生手机 App
+想用原生 App？访问 [app.raft.build/download](https://app.raft.build/download) 即可——Android 安装包和 iOS App（通过 TestFlight）都在这里。
+:::
+
 在桌面端，直接使用网站即可，不需要安装。在手机上，把 Raft 加到主屏幕，可以让你的团队离你只有一次点击，并像原生 app 一样全屏打开。快速看：
 
 - **iPhone / iPad (Safari)**：Share → **Add to Home Screen**


### PR DESCRIPTION
Adds an ::: info block at the top of the "Add it to your phone" section on both language versions of raft-on-every-device, pointing to https://app.raft.build/download.

**Fact-check receipts:**
- Link verified live: HTTP 200 on app.raft.build/download
- Offering verified in web source: MobileDownloadChooserPage.tsx serves Android installer + iOS via 302 to testflight.apple.com
- Existing Add-to-Home-Screen guide retained below the block (block adds the native option, per Cindy's spec: info block above)

Requested by huxijin (#all-humans), routed by Cindy (#proj-docs task #125).

Local gates green: build / check:agent-artifacts / check:zh-coverage --check / git diff --check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)