### PR TITLE
docs(login-with-raft): drop the 1.0.15 version pin; check the flag list, not a number

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -148,9 +148,11 @@ Owning an app does not publish it or make it available on other servers — publ
 
 The rest of the surface is on the CLI too — inspect with `list` and `status`, manage the logo with `logo` and `clear-logo`, manage private share links with `share-link`, `share-link-status` and `revoke-share-link`, request Marketplace review with `request-publish` and `request-unpublish`, and remove an unpublished app with `delete`.
 
-**If a command documented here returns `unknown command`, your Raft Computer is older than the feature — upgrade and try again.** Capabilities land in the CLI release by release, so a build from before a feature shipped simply does not have it. The App-management set arrived in **1.0.15**.
+**If a command documented here returns `unknown command`, your Raft Computer is older than the feature — upgrade and try again.** Capabilities land release by release, so a build from before a feature shipped simply does not have it.
 
-After that, your installed CLI is the authority on what it exposes: run `raft integration app --help` and treat its `Commands:` list as definitive. Anything absent from that list returns `unknown command` and names the valid set.
+Your installed CLI is the authority on what it exposes, and a version number is not — `raft --version` reports the CLI, while these capabilities ship in Computer numbering, so the two are not comparable. Run `raft integration app --help` and treat its `Commands:` list as definitive; anything absent from it returns `unknown command` and names the valid set.
+
+**Flags need their own check.** A flag your build does not have returns `unknown option`, not `unknown command`, and the list that settles it is `raft integration app <subcommand> --help`. Check there before relying on a flag — `rotate-secret --output` is the one that matters most, because it is what keeps a reissued secret out of the command's own output.
 
 ### The manual path
 

--- a/content/zh-cn/developers/login-with-raft/index.md
+++ b/content/zh-cn/developers/login-with-raft/index.md
@@ -118,9 +118,11 @@ npm create raft-app@latest my-raft-app -- --template pure-sign-in-web-app
 
 其他管理面也在 CLI 里：用 `list` 和 `status` 查看，用 `logo` 和 `clear-logo` 管理 logo，用 `share-link`、`share-link-status` 和 `revoke-share-link` 管理私有分享链接，用 `request-publish` 和 `request-unpublish` 请求市场审核，用 `delete` 删除未发布应用。
 
-**如果这里记录的命令返回 `unknown command`，说明你的 Raft Computer 早于该功能，需要升级后再试。** 功能会按 CLI 版本陆续发布，功能发布前的构建不会拥有它。应用管理命令集从 **1.0.15** 开始提供。
+**如果这里记录的命令返回 `unknown command`，说明你的 Raft Computer 早于该功能，需要升级后再试。** 能力是随版本陆续发布的，发布之前的构建就是没有它。
 
-之后，已安装的 CLI 就是它暴露能力的权威来源：运行 `raft integration app --help`，把它的 `Commands:` 列表当作准确信息。列表里没有的命令会返回 `unknown command`，并列出有效命令集。
+判断依据是已安装的 CLI，不是版本号：`raft --version` 报的是 CLI 版本，而这些能力按 Computer 版本发布，两者没法直接比。运行 `raft integration app --help`，把它的 `Commands:` 列表当作准确信息；列表里没有的命令会返回 `unknown command`，并列出有效命令集。
+
+**参数要单独查。** 你的构建没有的参数返回的是 `unknown option`，不是 `unknown command`，能给出答案的是 `raft integration app <子命令> --help`。依赖某个参数前先在那里确认——最需要确认的是 `rotate-secret --output`，因为正是它保证重新签发的 secret 不会出现在命令自己的输出里。
 
 ### 手动路径
 


### PR DESCRIPTION
Closes **task #95**.

## The pin

> The App-management set arrived in **1.0.15**.

Two things are wrong with it, and only one is the interesting one.

**It cannot be acted on.** `raft --version` reports the CLI — `0.0.18` on my carrier right now — while that pin is written in Computer/daemon numbering, which on the same carrier is `1.0.19`. A reader who runs the one command the page implies cannot tell which side of `1.0.15` they are on. The page also contradicted itself: one sentence earlier it attributed these releases to *CLI* numbering.

**It is also refuted.** `rotate-secret` was present on a carrier reporting daemon 1.0.14, i.e. before the pinned release. I am giving this as the weaker of the two reasons on purpose: it rests on a single observation and on trusting a version label, which is the same kind of evidence the pin itself rests on. The first reason does not depend on the label being right.

The page already carried the correct instrument two paragraphs down — `raft integration app --help` is definitive on every carrier, needs no maintenance, and cannot go stale. So the fix is to delete the number and lean on what was already there, not to substitute a better number.

## The gap that let this happen

The old guidance covered unknown **commands** only. A flag your build lacks returns `unknown option`, not `unknown command`, and it is settled by a different help target — `raft integration app <subcommand> --help` rather than `raft integration app --help`. Both verified on this carrier:

```
$ raft integration app definitely-not-a-command
Error: unknown command 'definitely-not-a-command'
Next action: Run `raft integration app --help` to list valid subcommands: ...

$ raft integration app rotate-secret --nosuchflag
Error: unknown option '--nosuchflag'
Next action: Run `raft integration app rotate-secret --help` to list supported flags.
```

That missing distinction is exactly what let `rotate-secret --output` sit in the Manual as an unconditional instruction, which is the defect in task #94. The Manual half is **botiverse/slock#7193**; this is the public half of the same mistake.

## Verification

- Command surface re-checked against the live CLI: all 14 subcommands it enumerates are on this page — 4 in the code block, 10 in the following paragraph. Nothing missing, nothing invented.
- `npm run build` exits 0; sitemap and redirect self-tests pass.
- Container nesting balanced in both edited files (checked separately — the build does not validate this, which is how a malformed `::: info` reached zh-cn before).
- Both locales changed together. `grep -rn "1\.0\.15" content/` now returns nothing.

## Requirement Challenge

**Which requirement should not exist?** "Tell readers which version added the feature." It reads as helpful precision and is the reason this line existed at all. It cannot survive contact with a product that versions the CLI and the Computer separately, and every attempt to keep it accurate costs maintenance forever. Cut, not corrected.

**Simplest viable version.** Delete one sentence. The extra paragraph about flags is not decoration — without it the page still only answers the `unknown command` case, and the `unknown option` case is the one that was actively misleading agents.

**Constraints and owners.** No policy cells or owner rulings are involved. The behavioural-check-over-version-label criterion is mine, set when I filed task #94 on 2026-08-03.
