### PR TITLE
docs(nav): move the Account section to the bottom of Features

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -137,13 +137,6 @@ export default defineConfig({
             },
           ],
           '/zh-cn/features/': [
-            {
-                text: '账号',
-                items: [
-                  { text: '账号基础', link: '/zh-cn/features/account/' },
-                  { text: '删除账号', link: '/zh-cn/features/account/deletion/' },
-                ],
-              },
               {
               text: '服务器',
               items: [
@@ -193,7 +186,14 @@ export default defineConfig({
                 { text: 'Comments on files', link: '/zh-cn/features/collaboration/comments/' },
               ],
             },
-          ],
+                {
+                text: '账号',
+                items: [
+                  { text: '账号基础', link: '/zh-cn/features/account/' },
+                  { text: '删除账号', link: '/zh-cn/features/account/deletion/' },
+                ],
+              },
+      ],
           '/zh-cn/developers/': [
             {
               text: 'Raft Apps',
@@ -397,13 +397,6 @@ export default defineConfig({
       // Collaboration are live; Connected Apps remains a placeholder.
       '/features/': [
         {
-          text: 'Account',
-          items: [
-            { text: 'Account Basics', link: '/features/account/' },
-            { text: 'Deleting your account', link: '/features/account/deletion/' },
-          ],
-        },
-        {
           text: 'Server',
           items: [
             { text: 'Server Basics', link: '/features/server/' },
@@ -451,6 +444,13 @@ export default defineConfig({
             // masked SVG ::after on these two links, keyed by href.
             { text: 'Connected Apps', link: '/features/apps/' },
             { text: 'Login with Raft', link: '/features/apps/login-with-raft/' },
+          ],
+        },
+        {
+          text: 'Account',
+          items: [
+            { text: 'Account Basics', link: '/features/account/' },
+            { text: 'Deleting your account', link: '/features/account/deletion/' },
           ],
         },
       ],


### PR DESCRIPTION
@artin's instruction in #proj-docs:600d1d26 — 「这个 account 章节不要放最上面呀，放最底下」.

## What changed

`Account` / `账号` was the **first** group in the Features sidebar in both locales, so a reader opening Features met account administration before Server, Agents or Messaging. It is reference material people go looking for, not an entry point. Now last in both.

```
EN before   Account · Server · Agents · Messaging · Collaboration · Apps & Integrations
EN after    Server · Agents · Messaging · Collaboration · Apps & Integrations · Account

zh before   账号 · 服务器 · Agent · Connected Apps · Messaging · Collaboration
zh after    服务器 · Agent · Connected Apps · Messaging · Collaboration · 账号
```

## Verification

- **Pure reorder**: 15 lines removed, 15 added, one file. No content, wording or link changes.
- All four `features/account/` links intact (2 EN, 2 zh).
- The Features tab already lands on `/features/server/`, so nothing else moves as a side effect.
- `npm run build` exits 0; redirect matcher self-test (8 cases) and sitemap-redirect check (84 URLs / 19 rules) both pass.

## One thing I noticed and did NOT change

The two locales order the middle groups differently, and always did:

```
EN   … Messaging · Collaboration · Apps & Integrations
zh   … Connected Apps · Messaging · Collaboration
```

`Connected Apps` sits 3rd in Chinese and 5th in English. That predates this PR and is a separate editorial call, so I left it. Flagging rather than silently folding it in — if the sections should agree, that is a decision someone should make deliberately, not inherit from a nav fix.

## Requirement Challenge

**Which requirement should not exist?** None to cut here — the instruction was one sentence and the change is one reorder. The thing I deliberately did *not* do is treat "fix the nav" as licence to also harmonise the locale ordering, rename groups, or move the Features landing link. A reorder that quietly does four things is harder to review than the four things separately.

**Simplest viable version.** This is it: move one block, both locales.

**Constraints and owners.** @artin owns this call and made it directly. The account pages themselves were simplified to his earlier instruction and are unchanged here.
