### PR TITLE
docs(nav): restore two orphaned EN links; align zh order to English

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -420,6 +420,7 @@ export default defineConfig({
         {
           text: 'Messaging',
           items: [
+            { text: 'Messaging Basics', link: '/features/messaging/' },
             { text: 'Channels', link: '/features/messaging/channels/' },
             { text: 'Messages', link: '/features/messaging/messages/' },
             { text: 'Threads', link: '/features/messaging/threads/' },
@@ -431,6 +432,7 @@ export default defineConfig({
         {
           text: 'Collaboration',
           items: [
+            { text: 'Collaboration Basics', link: '/features/collaboration/' },
             { text: 'Tasks', link: '/features/collaboration/tasks/' },
             { text: 'Files', link: '/features/collaboration/files/' },
             { text: 'Comments', link: '/features/collaboration/comments/' },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -137,7 +137,7 @@ export default defineConfig({
             },
           ],
           '/zh-cn/features/': [
-              {
+            {
               text: '服务器',
               items: [
                 { text: '服务器基础', link: '/zh-cn/features/server/' },
@@ -156,13 +156,6 @@ export default defineConfig({
                 { text: 'Reminders', link: '/zh-cn/features/agents/reminders/' },
                 { text: 'Troubleshooting', link: '/zh-cn/features/agents/troubleshooting/' },
                 { text: '外部 Agent', link: '/zh-cn/features/agents/external/' },
-              ],
-            },
-            {
-              text: 'Connected Apps',
-              items: [
-                { text: '概览', link: '/zh-cn/features/apps/' },
-                { text: 'Login with Raft', link: '/zh-cn/features/apps/login-with-raft/' },
               ],
             },
             {
@@ -186,14 +179,21 @@ export default defineConfig({
                 { text: 'Comments on files', link: '/zh-cn/features/collaboration/comments/' },
               ],
             },
-                {
-                text: '账号',
-                items: [
-                  { text: '账号基础', link: '/zh-cn/features/account/' },
-                  { text: '删除账号', link: '/zh-cn/features/account/deletion/' },
-                ],
-              },
-      ],
+            {
+              text: 'Connected Apps',
+              items: [
+                { text: '概览', link: '/zh-cn/features/apps/' },
+                { text: 'Login with Raft', link: '/zh-cn/features/apps/login-with-raft/' },
+              ],
+            },
+            {
+              text: '账号',
+              items: [
+                { text: '账号基础', link: '/zh-cn/features/account/' },
+                { text: '删除账号', link: '/zh-cn/features/account/deletion/' },
+              ],
+            },
+          ],
           '/zh-cn/developers/': [
             {
               text: 'Raft Apps',


### PR DESCRIPTION
Two nav fixes from @artin's questions in #proj-docs:600d1d26. He asked why the locale orders differed; the answer turned out to be "a stray insertion", but checking it found something worse.

## 1. The EN sidebar never linked two of its own pages

```
zh sidebar    /zh-cn/features/messaging/    /zh-cn/features/collaboration/
EN sidebar    (absent)                      (absent)
both pages    live, HTTP 200, both locales
```

Measured on the **served** site before the fix: the EN server page contained **0** links to `/features/messaging/`; the zh page contained **1**. Two live English pages were reachable only by typing the URL. Chinese readers could find them; English readers could not.

This follows the convention four of six groups already use rather than inventing one — `Server Basics`, `Agent Basics` and `Account Basics` all point at their section index as the first item. Messaging and Collaboration were the only two missing it, which is exactly why their indexes were orphaned.

Verified in the built output with a control:

```
out/features/server/index.html   /features/messaging/          1
                                 /features/collaboration/      1
                                 /features/server/computers/   1   ← control, already present
```

## 2. zh section order aligned to English

@artin: 「嗯，对齐英文」.

```
before  服务器 · Agent · Connected Apps · Messaging · Collaboration · 账号
after   服务器 · Agent · Messaging · Collaboration · Connected Apps · 账号
EN      Server · Agents · Messaging · Collaboration · Apps & Integrations · Account
```

`Connected Apps` had been third since #78 added the zh apps pages, appended beside Agent instead of matching English.

The zh groups are **rebuilt** rather than shuffled, so the check that matters is preservation, not the diff shape: **26 link items before, 26 after, identical as a set.** Nothing dropped, renamed or invented.

This also repairs damage from my own #95 earlier today: that move left the `账号` block at indentation 16/16 while every sibling used 12/14. It built fine, which is precisely why it would have survived unnoticed. All six groups are now uniform.

## Not in scope, deliberately

Group **labels** are untouched. `Agent` and `Connected Apps` are still untranslated beside `服务器`/`账号`, and the English group is `Apps & Integrations` while the Chinese one is `Connected Apps` — two names for one section. @artin routed copy decisions to @AngLee, so settling them inside a nav fix would be me taking a call that is not mine.

## Checks

`npm run build` exits 0; redirect matcher self-test (8 cases) and sitemap-redirect check (84 URLs / 19 rules) pass. EN untouched by the second commit; zh untouched by the first.

## Requirement Challenge

**Which requirement should not exist?** "Make the two sidebars match" as a single job. It bundles a real defect (orphaned pages — fix immediately, no decision needed), an ordering choice (someone's call, and @artin made it), and a copy question (a different owner entirely). Treating them as one task would have meant either stalling the bug fix behind a naming debate, or quietly making @AngLee's decision for them. Split by who owns the decision, not by which file they touch.

**Simplest viable version.** Two commits, one file, no content changes.
