### PR TITLE
docs(nav): apply @AngLee's zh sidebar group-name ruling

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -159,7 +159,7 @@ export default defineConfig({
               ],
             },
             {
-              text: 'Messaging',
+              text: '消息',
               items: [
                 { text: '概览', link: '/zh-cn/features/messaging/' },
                 { text: 'Channels', link: '/zh-cn/features/messaging/channels/' },
@@ -171,7 +171,7 @@ export default defineConfig({
               ],
             },
             {
-              text: 'Collaboration',
+              text: '协作',
               items: [
                 { text: '概览', link: '/zh-cn/features/collaboration/' },
                 { text: 'Tasks', link: '/zh-cn/features/collaboration/tasks/' },
@@ -180,7 +180,7 @@ export default defineConfig({
               ],
             },
             {
-              text: 'Connected Apps',
+              text: '应用与集成',
               items: [
                 { text: '概览', link: '/zh-cn/features/apps/' },
                 { text: 'Login with Raft', link: '/zh-cn/features/apps/login-with-raft/' },


### PR DESCRIPTION
Applies @AngLee's ruling from #proj-docs:600d1d26, made under @artin's already-approved **B policy** (common UI nouns → Chinese; product names / proper nouns / UI labels → English).

```
zh before   服务器 · Agent · Messaging · Collaboration · Connected Apps · 账号
zh after    服务器 · Agent · 消息 · 协作 · 应用与集成 · 账号
```

Three group labels, nothing else — `Messaging` → `消息`, `Collaboration` → `协作`, `Connected Apps` → `应用与集成`.

## Two calls in the ruling worth keeping visible

**`Agent` stays English and singular.** It is a product noun under B, treated the same as "Raft", and singular matches how the zh docs use the term throughout. English keeps plural `Agents` because that is ordinary English category-noun usage — a language difference, not an inconsistency to force into alignment.

**"Connected Apps" was a feature name promoted into a group name.** It belongs to Settings → Connected Apps. The group is the faithful translation of the English "Apps & Integrations"; the feature keeps its English name where it actually lives. So the two locales are now "one group, faithfully translated" rather than two different names.

## ⚠️ EN is unchanged, though a both-locale PR was requested

The ruling said to submit the PR for both locales. I measured the English sidebar against every point of it and **it already complies**: the group already reads `Apps & Integrations`, and plural `Agents` is explicitly endorsed by point 3. Editing EN to satisfy the letter of the request would have meant changing copy that the ruling itself declares correct — so I did not, and I am flagging it rather than letting a zh-only diff quietly under-deliver.

## Scope held deliberately

Item-level mixing inside groups (`概览` beside `Channels`, `Login with Raft`) is untouched. The ruling states plainly that this is what B prescribes, not drift — so "tidying" it would have been me overriding the copy owner inside a PR that exists to implement their decision.

## Verification

- Diff is 3 insertions / 3 deletions, all `text:` group labels.
- Replacements were applied **to the zh sidebar slice only**, so the identical English strings (`Messaging`, `Collaboration`) could not be caught by a global replace.
- zh feature links: **27 before, 27 after** — no item added, removed or relinked.
- `npm run build` exits 0; redirect matcher self-test (8 cases) and sitemap-redirect check (84 URLs / 19 rules) pass.

@AngLee said they will do the served readback after this lands.

## Requirement Challenge

**Which requirement should not exist?** "Change both locales." It was reasonable when written — the asker could not know EN already complied — but executing it literally would have degraded correct copy. The requirement worth keeping is the *outcome* (both locales conform to B), and one of them already did.

**Constraints and owners.** @AngLee owns Chinese copy and made every naming call here; @artin owns the B policy underneath it. I implemented and verified, and changed no wording of my own.
