### PR TITLE
service-cli-migration: name the reusable session-store implementation

### DIFF
--- a/content/developers/best-practices/service-cli-migration/index.md
+++ b/content/developers/best-practices/service-cli-migration/index.md
@@ -81,6 +81,25 @@ Token endpoints need stricter network behavior than ordinary API requests:
 - reject unknown response fields and already-expired sessions
 - make lock ownership explicit; never break a lock only because time passed if the owner may still be alive
 
+### Reusable implementation
+
+The admission and storage rules above are packaged as [`@botiverse/agent-session-store`](https://www.npmjs.com/package/@botiverse/agent-session-store) (npm, ESM, Node 20+, no runtime dependencies). It is service-agnostic: the `<service>` slug is a parameter, never a default.
+
+```ts
+import { admitAgent, writeAgentSession, readAgentSession } from "@botiverse/agent-session-store";
+
+const admission = admitAgent();          // { kind: "human" } | { kind: "agent", env } | { kind: "fail_closed", reason }
+if (admission.kind === "fail_closed") throw new Error(admission.reason); // never fall back to the host HOME
+if (admission.kind === "agent") {
+  writeAgentSession(admission.env, "my-service", session, apiBase);     // 0700 dirs, 0600 file, temp + atomic rename
+  const stored = readAgentSession(admission.env, "my-service");         // full record for refresh, or null
+}
+```
+
+What it does: fail-closed detection of the three daemon markers and an executable `raft` wrapper; the canonical per-agent path with slug validation and root containment; the atomic 0600/0700 write that leaves the previous session intact on failure; typed readers for the stored `raft-cli-agent-session.v1` record.
+
+What it deliberately does not do: PKCE, the `agent-login` invoke, the exchange and refresh requests, the cross-process refresh lock, or any HTTP. Those stay in each service CLI so that no service protocol leaks into the shared package. Two CLIs consume it today: [`@botiverse/hands-cli`](https://www.npmjs.com/package/@botiverse/hands-cli) and [`@botiverse/testbed-cli`](https://www.npmjs.com/package/@botiverse/testbed-cli); the latter adopted it unchanged and reached a working agent login on the first live attempt.
+
 ## Preserve existing action callers
 
 Do not remove working actions just because the CLI exists.

--- a/content/zh-cn/developers/best-practices/service-cli-migration/index.md
+++ b/content/zh-cn/developers/best-practices/service-cli-migration/index.md
@@ -82,6 +82,25 @@ token endpoint 需要比普通 API 请求更严格的网络行为：
 - 拒绝未知的响应字段和已经过期的 session
 - 把 lock 归属显式化；不要只因为时间过去就破坏一把锁，因为 owner 可能仍然存活
 
+### 可复用实现
+
+上面的准入与存储规则已经打包为 [`@botiverse/agent-session-store`](https://www.npmjs.com/package/@botiverse/agent-session-store)（npm，ESM，Node 20+，无运行时依赖）。它不绑定任何服务：`<service>` slug 是参数，没有默认值。
+
+```ts
+import { admitAgent, writeAgentSession, readAgentSession } from "@botiverse/agent-session-store";
+
+const admission = admitAgent();          // { kind: "human" } | { kind: "agent", env } | { kind: "fail_closed", reason }
+if (admission.kind === "fail_closed") throw new Error(admission.reason); // 绝不回退到宿主用户的 HOME
+if (admission.kind === "agent") {
+  writeAgentSession(admission.env, "my-service", session, apiBase);     // 目录 0700、文件 0600、临时文件 + 原子 rename
+  const stored = readAgentSession(admission.env, "my-service");         // 供刷新使用的完整记录，或 null
+}
+```
+
+它做的事：对三个 daemon 标记和可执行的 `raft` 包装器做 fail-closed 检测；带 slug 校验和根目录约束的 agent 专属路径；失败时保留上一份会话的原子 0600/0700 写入；对已存储的 `raft-cli-agent-session.v1` 记录提供带类型的读取。
+
+它刻意不做的事：PKCE、`agent-login` 调用、exchange 与 refresh 请求、跨进程刷新锁，以及任何 HTTP。这些留在各服务的 CLI 里，避免服务协议渗入共享包。目前有两个 CLI 使用它：[`@botiverse/hands-cli`](https://www.npmjs.com/package/@botiverse/hands-cli) 与 [`@botiverse/testbed-cli`](https://www.npmjs.com/package/@botiverse/testbed-cli)；后者未做任何修改即接入，并在第一次真实 agent 登录中即跑通。
+
 ## 保留既有操作调用方
 
 不要因为 CLI 存在就移除还能用的操作。


### PR DESCRIPTION
The page states the admission and storage contract (three daemon markers, fail-closed, the per-agent path, 0700/0600, atomic rename) but never tells the reader an implementation exists. This adds a short **Reusable implementation** subsection under *Store and refresh safely*, in English and Chinese, pointing at [`@botiverse/agent-session-store`](https://www.npmjs.com/package/@botiverse/agent-session-store): a minimal usage snippet, what it does, what it deliberately does not do (no PKCE, no HTTP, no refresh lock — those stay per service), and the two consumers (`hands-cli`, `testbed-cli`).

The snippet uses `readAgentSession`, which ships in 0.2.0 (botiverse/hands PR opened alongside); the rest is in 0.1.0.

Requested by artin 2026-09-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)