### PR TITLE
docs(oauth): reject redirects in credential examples

### DIFF
--- a/content/developers/login-with-raft/index.md
+++ b/content/developers/login-with-raft/index.md
@@ -439,6 +439,9 @@ async function exchangeRaftCode(code: string) {
     `${process.env.RAFT_API_ORIGIN}/api/oauth/token`,
     {
       method: "POST",
+      // Worker runtimes support manual/follow only. Reject redirects before
+      // parsing: never send the client secret to a Location target.
+      redirect: "manual",
       headers: {
         "content-type": "application/json",
         authorization:
@@ -455,6 +458,9 @@ async function exchangeRaftCode(code: string) {
     }
   );
 
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error("Raft token exchange redirect rejected");
+  }
   if (!response.ok) {
     throw new Error("Raft token exchange failed");
   }
@@ -473,12 +479,17 @@ async function fetchRaftUserinfo(
   const response = await fetch(
     `${process.env.RAFT_API_ORIGIN}/api/oauth/userinfo`,
     {
+      // Do not follow a redirect carrying a bearer token across origins.
+      redirect: "manual",
       headers: {
         authorization: `Bearer ${accessToken}`,
       },
     }
   );
 
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error("Raft userinfo redirect rejected");
+  }
   if (!response.ok) {
     throw new Error("Raft userinfo failed");
   }

--- a/content/zh-cn/developers/login-with-raft/index.md
+++ b/content/zh-cn/developers/login-with-raft/index.md
@@ -400,6 +400,9 @@ async function exchangeRaftCode(code: string) {
     `${process.env.RAFT_API_ORIGIN}/api/oauth/token`,
     {
       method: "POST",
+      // Worker runtimes support manual/follow only. Reject redirects before
+      // parsing: never send the client secret to a Location target.
+      redirect: "manual",
       headers: {
         "content-type": "application/json",
         authorization:
@@ -416,6 +419,9 @@ async function exchangeRaftCode(code: string) {
     }
   );
 
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error("Raft token exchange redirect rejected");
+  }
   if (!response.ok) {
     throw new Error("Raft token exchange failed");
   }
@@ -434,12 +440,17 @@ async function fetchRaftUserinfo(
   const response = await fetch(
     `${process.env.RAFT_API_ORIGIN}/api/oauth/userinfo`,
     {
+      // Do not follow a redirect carrying a bearer token across origins.
+      redirect: "manual",
       headers: {
         authorization: `Bearer ${accessToken}`,
       },
     }
   );
 
+  if (response.status >= 300 && response.status < 400) {
+    throw new Error("Raft userinfo redirect rejected");
+  }
   if (!response.ok) {
     throw new Error("Raft userinfo failed");
   }


### PR DESCRIPTION
The Login with Raft docs show credential-bearing `fetch` examples without a redirect policy. On Cloudflare Workers, `redirect: "error"` is unsupported; the safe portable mode is `manual` followed by explicit 3xx rejection. Without this, a 307 can carry the OAuth client secret or bearer token to its Location target.

Update the English and Chinese callback examples for token exchange and userinfo to use `redirect: "manual"` and reject 3xx before parsing. This documents the behavior already required by the deployed Release App Worker fix.

## Requirement Challenge

The existing docs promise production OAuth examples and exact callback security. Add only the missing runtime redirect guard; no new OAuth endpoint, scope, or product behavior. Preserve the English/Chinese parity. Human final approval remains required before merge.

## Validation

- `pnpm run check:zh-coverage` passes.
- `pnpm run build` passes: VitePress render, agent artifact generation, sitemap redirect checks.
- `git diff --check` passes.
- No credentials or network calls were used by validation.

## Automate-Readiness

Examples now work in Workers and Node-style runtimes while rejecting cross-origin redirects before credential-bearing response parsing. The docs do not claim that a token exchange or userinfo request succeeded; they show the failure behavior explicitly.
