### PR TITLE
docs(zh-cn): redirect features index out of sitemap

### DIFF
--- a/content/public/_redirects
+++ b/content/public/_redirects
@@ -14,6 +14,8 @@
 /developers/  /developers/login-with-raft/  301
 /features  /features/server/  301
 /features/  /features/server/  301
+/zh-cn/features  /zh-cn/features/server/  301
+/zh-cn/features/  /zh-cn/features/server/  301
 /agent-knowledge  /welcome/  302
 /agent-knowledge/  /welcome/  302
 /agent-knowledge/*  /welcome/  302

--- a/scripts/check-sitemap-redirects.mjs
+++ b/scripts/check-sitemap-redirects.mjs
@@ -34,6 +34,23 @@ function sitemapPaths() {
   )
 }
 
+function htmlOutputPathForSitemapPath(path) {
+  const cleanPath = path.split(/[?#]/, 1)[0]
+  if (!cleanPath.startsWith('/')) {
+    throw new Error(`Sitemap path must be absolute: ${path}`)
+  }
+
+  if (cleanPath.endsWith('/')) {
+    return resolve(root, 'out', cleanPath.slice(1), 'index.html')
+  }
+
+  return resolve(root, 'out', `${cleanPath.slice(1)}.html`)
+}
+
+function hasMetaRefresh(html) {
+  return /<meta\b(?=[^>]*\bhttp-equiv=["']?refresh["']?)[^>]*>/i.test(html)
+}
+
 /**
  * Regression teeth for the matcher, run against the REAL redirect table.
  *
@@ -48,9 +65,11 @@ function selfTest() {
     // [path, should be treated as redirected away]
     ['/', true], //                       exact rule -> /welcome/
     ['/features/', true], //              exact rule -> /features/server/
+    ['/zh-cn/features/', true], //         locale exact rule -> /zh-cn/features/server/
     ['/welcome/', false], //              destination; the `/welcome -> /welcome/`
     //                                    canonicalisation rule must not hit it
     ['/features/server/', false], //      destination
+    ['/zh-cn/features/server/', false], // locale destination
     ['/agent-knowledge/review-probe/', true], // terminal wildcard, the case
     //                                    @meichen proved was leaking
     ['/agent-knowledge/', true], //       wildcard prefix boundary
@@ -106,7 +125,22 @@ if (offenders.length > 0) {
   process.exit(1)
 }
 
+const metaRefreshPages = paths.filter((path) =>
+  hasMetaRefresh(readFileSync(htmlOutputPathForSitemapPath(path), 'utf-8')),
+)
+
+if (metaRefreshPages.length > 0) {
+  console.error(
+    'Sitemap lists HTML pages that contain a meta refresh:\n' +
+      metaRefreshPages.map((p) => `  - ${p}`).join('\n') +
+      '\n\nA sitemap must contain only canonical, directly useful pages.' +
+      '\nFix: replace the meta-refresh page with real content, or add a formal ' +
+      'redirect that the sitemap filter can see.',
+  )
+  process.exit(1)
+}
+
 console.log(
   `sitemap-redirects OK — ${paths.length} sitemap URLs checked against ` +
-    `${rules.length} redirect rules, no overlap.`,
+    `${rules.length} redirect rules, no overlap or meta refresh.`,
 )


### PR DESCRIPTION
## Summary
- add formal `/zh-cn/features` and `/zh-cn/features/` 301 redirects to `/zh-cn/features/server/`, mirroring the English `/features/` behavior
- extend the sitemap hygiene check so sitemap-listed built HTML pages containing meta refresh fail the build, in addition to `_redirects` overlap

## Validation
- `pnpm build` PASS: `sitemap-redirects OK — 81 sitemap URLs checked against 25 redirect rules, no overlap or meta refresh.`
- `pnpm check:zh-coverage -- --check` PASS: 42 English / 42 zh-CN / 42 paired / 0 missing
- `node scripts/check-sitemap-redirects.mjs --self-test` PASS: 10 cases
- `git diff --check` PASS
- Sitemap readback from built `out/sitemap.xml`: count 81, bare `https://docs.raft.build/zh-cn/features/` absent, destination `https://docs.raft.build/zh-cn/features/server/` present
- Right-cause mutation 1: removing the new zh-CN redirect rules makes `pnpm build` fail in redirect matcher self-test for `/zh-cn/features/`
- Right-cause mutation 2: adding a meta-refresh tag to sitemap-listed `/zh-cn/features/server/` makes `pnpm build` fail and name `/zh-cn/features/server/`; restoring returns green

## Scope
No deploy. This leaves the placeholder source page in place but removes it from the sitemap via the same redirect path used by English `/features/`.

Task: #170