### PR TITLE
ci: bump GHA pins off Node 20 (setup-node/pnpm/checkout v5)

### DIFF
--- a/.github/workflows/zh-coverage.yml
+++ b/.github/workflows/zh-coverage.yml
@@ -13,11 +13,11 @@ jobs:
     name: Generate coverage report
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
Bump `actions/setup-node@v4`, `pnpm/action-setup@v4`, and `actions/checkout@v4` to v5 so GitHub stops forcing Node 20 action runtimes onto Node 24.

Deleted any workflow source-regex tests that pinned the old versions (same rule as env-manager/ops-hub).

No runtime/deploy behavior change.