### PR TITLE
docs(apps): distinguish Agent Events from App Notifications

### DIFF
--- a/content/developers/raft-apps/build/index.md
+++ b/content/developers/raft-apps/build/index.md
@@ -86,7 +86,8 @@ If your app is for agents, decide how agents should use it:
 
 - **Agent Login with Raft** lets an agent sign into your app as itself.
 - **Agent action manifests** let Raft discover callable app actions.
-- **App Notifications** (experimental) let an installed app send structured events or notifications to a selected agent.
+- **Agent Events API** (experimental) lets an available app send a structured event or notification to one selected Agent.
+- **App Notifications** (experimental) lets an App installation read approved Raft projections and subscribe to approved Raft-to-App events through a signed webhook.
 
 Only expose operations your app can execute safely. Treat app-controlled payloads as data, not instructions. An event can inform an agent that something happened; it does not authorize the app to command the agent.
 
@@ -102,7 +103,7 @@ Before requesting review or sharing the app with another server, test:
 - agent login fails closed until the app is available to the server
 - userinfo and serverinfo are refreshed from Raft instead of cached indefinitely
 - uninstalling or revoking the app removes access
-- manifest actions and notifications reject undeclared scopes or unavailable servers
+- manifest actions, Agent Events API calls, and App Notifications reject undeclared permissions or unavailable servers
 
 ## Publish to the marketplace
 

--- a/content/developers/raft-apps/index.md
+++ b/content/developers/raft-apps/index.md
@@ -6,7 +6,7 @@ llms_summary: "Read when you need a high-level overview of what Raft Apps are an
 
 # Raft Apps
 
-Raft Apps are external tools that plug into a Raft server. They can let humans and agents sign in with their Raft identity, expose agent actions through a manifest, and send structured app notifications to agents when the server has installed or registered the app.
+Raft Apps are external tools that plug into a Raft server. They can let humans and agents sign in with their Raft identity, expose agent actions through a manifest, send structured events to an Agent through the Agent Events API, and use installation-approved App Notifications data or events.
 
 Use this page when you are deciding what kind of app to build. Use [Build a Raft App](/developers/raft-apps/build/) when you are ready to scaffold and register one. If an existing action surface is growing into a full SDK, read [Migrate Agent Actions to a Service CLI](/developers/best-practices/service-cli-migration/). Use [Login with Raft](/developers/login-with-raft/) when you need the OAuth protocol details.
 
@@ -17,9 +17,10 @@ A Raft App can provide one or more of these surfaces:
 - **Human Login with Raft** — a person signs into your app through Raft instead of creating a separate account.
 - **Agent Login with Raft** — an agent signs into your app as itself, with a grant scoped to one app, one server, and one agent.
 - **Agent actions** — your app publishes a manifest so Raft agents can discover and call supported actions. When that surface grows, keep compatibility actions and [move new capabilities into an authenticated service CLI](/developers/best-practices/service-cli-migration/).
-- **App Notifications** (experimental) — an installed app can send structured events or notifications to a selected agent.
+- **Agent Events API** (experimental) — an available app can send a structured event or notification to one selected Agent. This is App-to-Agent information, not remote command execution.
+- **App Notifications** (experimental) — an App installation can read approved Raft projections and subscribe to approved Raft-to-App events. A signed webhook is the delivery transport, not an App-to-Agent channel.
 
-These surfaces are independent. A simple app might only use human login. A workflow app might combine human login, agent login, manifest actions, and notifications.
+These surfaces are independent. A simple app might only use human login. A workflow app might combine principal login, manifest actions, Agent Events API delivery, and installation-scoped App Notifications.
 
 ## Availability model
 
@@ -45,7 +46,7 @@ Use the same ownership rule for every app: fix the app when it violates the publ
 
 Most apps follow this path:
 
-1. Decide which surfaces you need: login, agent actions, notifications, or a combination.
+1. Decide which surfaces you need: login, agent actions, Agent Events API delivery, App Notifications, or a combination.
 2. Scaffold or implement the app using [Build a Raft App](/developers/raft-apps/build/).
 3. Register the app in Raft with its name, homepage, callback URL, primary category, and optional manifest URL.
 4. Generate a client secret and keep it server-only.
@@ -80,5 +81,5 @@ Use the examples as implementation references, then verify the exact contract yo
 
 - Start with [Build a Raft App](/developers/raft-apps/build/) for scaffolding, local development, registration, and testing.
 - Read [Migrate Agent Actions to a Service CLI](/developers/best-practices/service-cli-migration/) when a manifest has outgrown a small action surface.
-- Read [Login with Raft](/developers/login-with-raft/) for setup URLs, callback handling, token exchange, userinfo, serverinfo, agent access, and app notifications.
+- Read [Login with Raft](/developers/login-with-raft/) for setup URLs, callback handling, token exchange, userinfo, serverinfo, agent access, and the Agent Events API.
 - Read [Connected Apps](/features/apps/) for the user-facing marketplace, install, uninstall, and server-admin model.

--- a/content/zh-cn/developers/raft-apps/build/index.md
+++ b/content/zh-cn/developers/raft-apps/build/index.md
@@ -86,7 +86,8 @@ Agent 可以准备这次注册：`raft integration app prepare register` 会发�
 
 - **Agent Login with Raft** 让 Agent 以自己的身份登录你的应用。
 - **Agent action manifests** 让 Raft 发现可调用的应用操作。
-- **应用通知**（实验性）让已安装应用向选定 Agent 发送结构化事件或通知。
+- **Agent Events API**（实验性）让可用的应用向一个选定 Agent 发送结构化事件或通知。
+- **App Notifications**（实验性）让 App installation 读取已批准的 Raft 投影，并通过签名 webhook 订阅已批准的 Raft 到 App 事件。
 
 只暴露你的应用可以安全执行的操作。把应用控制的 payload 当作数据，而不是指令。事件可以告诉 Agent 发生了什么；它不会授权应用命令 Agent。
 
@@ -102,7 +103,7 @@ Agent 可以准备这次注册：`raft integration app prepare register` 会发�
 - Agent 登录在应用对服务器不可用前 fail closed
 - userinfo 和 serverinfo 会从 Raft 刷新，而不是无限期缓存
 - 卸载或撤销应用会移除访问权
-- manifest 操作和通知会拒绝未声明 scope 或不可用服务器
+- manifest 操作、Agent Events API 调用和 App Notifications 会拒绝未声明权限或不可用服务器
 
 ## 发布到市场
 

--- a/content/zh-cn/developers/raft-apps/index.md
+++ b/content/zh-cn/developers/raft-apps/index.md
@@ -6,7 +6,7 @@ llms_summary: "当你需要用简体中文了解 Raft Apps 是什么，以及如
 
 # Raft Apps（Raft 应用）
 
-Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Agent 用自己的 Raft 身份登录，让 Agent 通过 manifest 发现并调用操作，也可以在服务器安装或注册应用后，向 Agent 发送结构化的应用通知。
+Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Agent 用自己的 Raft 身份登录，让 Agent 通过 manifest 发现并调用操作，通过 Agent Events API 向一个 Agent 发送结构化事件，也可以使用 installation 批准的 App Notifications 数据与事件能力。
 
 如果你正在判断应该构建哪一种应用，先读这一页。准备开始脚手架和注册时，读 [构建 Raft App](/zh-cn/developers/raft-apps/build/)。需要 OAuth 协议细节时，读 [Login with Raft](/zh-cn/developers/login-with-raft/)。
 
@@ -17,9 +17,10 @@ Raft Apps 是接入 Raft 服务器的外部工具。它们可以让人类和 Age
 - **Human Login with Raft**（人类登录）—— 人可以通过 Raft 登录你的应用，而不是单独创建账号。
 - **Agent Login with Raft**（Agent 登录）—— Agent 可以以自己的身份登录你的应用，授权范围限定为单个应用、单个服务器和单个 Agent。
 - **Agent 操作** —— 你的应用发布 manifest，让 Raft Agent 能够发现并调用支持的操作。
-- **应用通知**（实验性）—— 已安装的应用可以向选定 Agent 发送结构化事件或通知。
+- **Agent Events API**（实验性）—— 可用的应用可以向一个选定 Agent 发送结构化事件或通知。这是 App 到 Agent 的信息，不是远程命令执行。
+- **App Notifications**（实验性）—— App installation 可以读取已批准的 Raft 投影，并订阅已批准的 Raft 到 App 事件。签名 webhook 只是投递机制，不是 App 到 Agent 的通道。
 
-这些能力彼此独立。简单应用可能只需要人类登录；工作流应用可能同时使用人类登录、Agent 登录、manifest 操作和应用通知。
+这些能力彼此独立。简单应用可能只需要人类登录；工作流应用可能同时使用主体登录、manifest 操作、Agent Events API 投递和 installation-scoped App Notifications。
 
 ## 可用性模型
 
@@ -45,7 +46,7 @@ Raft 客户端源码、Computer 存储和 session 文件、内部 proxy、未发
 
 大多数应用会走这条路径：
 
-1. 决定需要哪些能力：登录、Agent 操作、通知，或它们的组合。
+1. 决定需要哪些能力：登录、Agent 操作、Agent Events API 投递、App Notifications，或它们的组合。
 2. 使用 [构建 Raft App](/zh-cn/developers/raft-apps/build/) 脚手架或实现应用。
 3. 在 Raft 中注册应用，填入名称、主页、回调 URL、主分类，以及可选的 manifest URL。
 4. 生成客户端密钥，并只保存在服务端。
@@ -79,5 +80,5 @@ Agent 授权也限定到单个 Agent。一个 Agent 不能复用另一个 Agent 
 ## 下一步
 
 - 从 [构建 Raft App](/zh-cn/developers/raft-apps/build/) 开始，完成脚手架、本地开发、注册和测试。
-- 阅读 [Login with Raft](/zh-cn/developers/login-with-raft/)，了解 setup URL、回调处理、token exchange、userinfo、serverinfo、Agent access 和应用通知。
+- 阅读 [Login with Raft](/zh-cn/developers/login-with-raft/)，了解 setup URL、回调处理、token exchange、userinfo、serverinfo、Agent access 和 Agent Events API。
 - 阅读 [Connected Apps](/zh-cn/features/apps/)，了解面向用户的 marketplace、安装、卸载和服务器管理员模型。


### PR DESCRIPTION
## Summary

- correct the Raft Apps overview so App-to-Agent delivery is named **Agent Events API**
- reserve **App Notifications** for installation-scoped reads and Raft-to-App webhook events
- keep English and zh-CN overview/build guides aligned

## Requirement Challenge

- **Requirement kept:** user and developer docs must use the same direction-aware names as the App platform contract.
- **Cut:** no new endpoint tutorial or unshipped server-local installation claim; this PR only fixes the misleading capability overview.
- **Simplest version:** four paired overview pages, no navigation or schema changes.
- **Constraint owner:** Raft App DRI; App Notifications remains experimental and permission-gated.

## Verification

- `pnpm run check:zh-coverage`
- `pnpm run build` (VitePress render, agent artifacts, sitemap/redirect checks)
- `git diff --check`
